### PR TITLE
Correct format of TimeEntries on Reports. Closes #488, #485

### DIFF
--- a/Joey/UI/Views/BarChart.cs
+++ b/Joey/UI/Views/BarChart.cs
@@ -148,7 +148,7 @@ namespace Toggl.Joey.UI.Views
                     row.RelativeWidth = barWidth;
                     row.BarView.BillableTime = activity.BillableTime;
                     row.BarView.TotalTime = activity.TotalTime;
-                    row.ValueTextView.Text = FormatTime (activity.TotalTime);
+                    row.ValueTextView.Text = activity.FormattedTotalTime;
                     row.ValueTextView.Visibility = showValueLabels ? ViewStates.Visible : ViewStates.Gone;
                     row.YAxisTextView.Text = yLabel;
                     row.YAxisTextView.Visibility = showYAxis ? ViewStates.Visible : ViewStates.Gone;
@@ -305,15 +305,6 @@ namespace Toggl.Joey.UI.Views
                     tv.Layout (axisX, axisY, axisX + tv.MeasuredWidth, axisY + tv.MeasuredHeight);
                 }
             }
-        }
-
-        private static string FormatTime (long seconds)
-        {
-            if (seconds == 0) {
-                return String.Empty;
-            }
-            var t = TimeSpan.FromSeconds (seconds);
-            return String.Format ("{0}:{1:mm}", (int)t.TotalHours, t);
         }
 
         private class BackgroundView : View

--- a/Phoebe/Data/Json/Converters/ReportJsonConverter.cs
+++ b/Phoebe/Data/Json/Converters/ReportJsonConverter.cs
@@ -84,7 +84,16 @@ namespace Toggl.Phoebe.Data.Json.Converters
         private static long ToLong (string s)
         {
             long l;
-            long.TryParse (s, out l);
+
+            // round decimal values
+            if (!string.IsNullOrEmpty (s) && s.Contains (".")) {
+                double d;
+                double.TryParse (s, out d);
+                l = (long)Math.Round (d);
+            } else {
+                long.TryParse (s, out l);
+            }
+
             return l;
         }
     }

--- a/Phoebe/Data/Models/TimeEntryModel.cs
+++ b/Phoebe/Data/Models/TimeEntryModel.cs
@@ -229,7 +229,7 @@ namespace Toggl.Phoebe.Data.Models
         public string GetFormattedDuration ()
         {
             TimeSpan duration = GetDuration (Data, Time.UtcNow);
-            string formattedString = duration.ToString (@"h\:mm\:ss");
+            string formattedString = duration.ToString (@"hh\:mm\:ss");
             var user = ServiceContainer.Resolve<AuthManager> ().User;
 
             if (user == null) {

--- a/Phoebe/Data/ReportTypes.cs
+++ b/Phoebe/Data/ReportTypes.cs
@@ -16,6 +16,8 @@ namespace Toggl.Phoebe.Data
         public long BillableTime { get; set; }
 
         public long TotalTime { get; set; }
+
+        public string FormattedTotalTime { get; set; }
     }
 
     public struct ReportProject {

--- a/Phoebe/Data/Reports/SummaryReportView.cs
+++ b/Phoebe/Data/Reports/SummaryReportView.cs
@@ -305,8 +305,9 @@ namespace Toggl.Phoebe.Data.Reports
 
         private string getFormattedTime ( UserData user, long totalTime)
         {
-            TimeSpan duration = TimeSpan.FromMilliseconds ( totalTime);
-            string formattedString = duration.ToString (@"h\:mm\:ss");
+            TimeSpan duration = TimeSpan.FromMilliseconds ( Time.UtcNow.Millisecond + totalTime);
+            decimal totalHours = Math.Floor ((decimal)duration.TotalHours);
+            string formattedString = String.Format ("{0}:{1}:{2}", (int)totalHours, duration.ToString (@"mm"), duration.ToString (@"ss"));
 
             if ( user!= null) {
                 if ( user.DurationFormat == DurationFormat.Classic) {
@@ -314,8 +315,6 @@ namespace Toggl.Phoebe.Data.Reports
                         formattedString = duration.ToString (@"s\ \s\e\c");
                     } else if (duration.TotalMinutes > 1 && duration.TotalMinutes < 60) {
                         formattedString = duration.ToString (@"mm\:ss\ \m\i\n");
-                    } else {
-                        formattedString = duration.ToString (@"hh\:mm\:ss");
                     }
                 } else if (user.DurationFormat == DurationFormat.Decimal) {
                     formattedString = String.Format ("{0:0.00} h", duration.TotalHours);
@@ -332,6 +331,19 @@ namespace Toggl.Phoebe.Data.Reports
                 project.FormattedBillableTime = getFormattedTime (user, project.BillableTime);
                 items[i] = project;
             }
+        }
+
+        private TimeSpan GetDuration (TimeEntryData data, DateTime now)
+        {
+            if (data.StartTime == DateTime.MinValue) {
+                return TimeSpan.Zero;
+            }
+
+            var duration = (data.StopTime ?? now) - data.StartTime;
+            if (duration < TimeSpan.Zero) {
+                duration = TimeSpan.Zero;
+            }
+            return duration;
         }
 
         private ReportData CreateEmptyReport()

--- a/Ross/Views/Charting/BarChartView.cs
+++ b/Ross/Views/Charting/BarChartView.cs
@@ -156,8 +156,7 @@ namespace Toggl.Ross.Views.Charting
 
         public string TimeForBarAtIndex (int index)
         {
-            TimeSpan duration = TimeSpan.FromSeconds ( ActivityList [index].TotalTime);
-            return String.Format ("{0:0.00}", duration.TotalHours);
+            return ActivityList [index].FormattedTotalTime;
         }
 
         #endregion


### PR DESCRIPTION
- Correct format.
- Now Barchart labels are formatted with the format selected by the user ( with minor modifications). The final result is equal to web barchart.

Fixes #488, #485
