### PR TITLE
Set new projects as private by default. Closes #521

### DIFF
--- a/Joey/UI/Fragments/CreateProjectDialogFragment.cs
+++ b/Joey/UI/Fragments/CreateProjectDialogFragment.cs
@@ -151,15 +151,16 @@ namespace Toggl.Joey.UI.Fragments
 
                 ProjectModel project;
                 var dataStore = ServiceContainer.Resolve<IDataStore> ();
-                var existingProjectData = await dataStore.Table<ProjectData>().QueryAsync ( p => p.Name == nameEditText.Text && p.ClientId == null);
+                var existingProjectData = await dataStore.Table<ProjectData>().QueryAsync (p => p.Name == nameEditText.Text && p.ClientId == null);
 
                 if (existingProjectData.Count > 0) {
-                    project = new ProjectModel ( existingProjectData.First());
+                    project = new ProjectModel (existingProjectData.First());
                 } else {
-                    project = new ProjectModel () {
+                    project = new ProjectModel {
                         Workspace = workspaceModel,
                         Name = nameEditText.Text,
-                        Color = ProjectColor
+                        Color = ProjectColor,
+                        IsPrivate = true
                     };
                 }
 

--- a/Ross/ViewControllers/NewProjectViewController.cs
+++ b/Ross/ViewControllers/NewProjectViewController.cs
@@ -24,10 +24,11 @@ namespace Toggl.Ross.ViewControllers
 
         public NewProjectViewController (WorkspaceModel workspace, int color)
         {
-            this.model = new ProjectModel () {
+            model = new ProjectModel {
                 Workspace = workspace,
                 Color = color,
                 IsActive = true,
+                IsPrivate = true
             };
             Title = "NewProjectTitle".Tr ();
         }
@@ -124,8 +125,8 @@ namespace Toggl.Ross.ViewControllers
             try {
                 // Check for existing name
                 var dataStore = ServiceContainer.Resolve<IDataStore> ();
-                Guid clientId = ( model.Client == null) ?  Guid.Empty : model.Client.Id;
-                var existWithName = await dataStore.Table<ProjectData>().ExistWithNameAsync ( model.Name, clientId);
+                Guid clientId = (model.Client == null) ?  Guid.Empty : model.Client.Id;
+                var existWithName = await dataStore.Table<ProjectData>().ExistWithNameAsync (model.Name, clientId);
 
                 if (existWithName) {
                     var alert = new UIAlertView (


### PR DESCRIPTION
Set new projects created by users using the app with is_private=true by default. Is the correct behaviour. 
Needs to add a switcher to define public or private if user is admin.

Fixes #521.