### PR TITLE
TE Cosmetic Changes

### DIFF
--- a/Joey/Resources/drawable/TagsView.xml
+++ b/Joey/Resources/drawable/TagsView.xml
@@ -4,10 +4,10 @@
     <solid android:color="#4dd965" />
 
     <corners
-        android:bottomLeftRadius="3dp"
-        android:bottomRightRadius="3dp"
-        android:topLeftRadius="3dp"
-        android:topRightRadius="3dp" >
+        android:bottomLeftRadius="2px"
+        android:bottomRightRadius="2px"
+        android:topLeftRadius="2px"
+        android:topRightRadius="2px" >
     </corners>
 
 </shape>

--- a/Joey/Resources/layout/EditTimeEntryFragment.axml
+++ b/Joey/Resources/layout/EditTimeEntryFragment.axml
@@ -44,7 +44,7 @@
                         android:id="@+id/textView1"
                         android:layout_marginBottom="0.0dp"
                         android:layout_marginTop="0.0dp"
-                        android:textSize="14dp"
+                        android:textSize="16sp"
                         android:textColor="@color/material_gray_transparent" />
                     <EditText
                         android:id="@+id/StartTimeEditText"
@@ -75,7 +75,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:id="@+id/textView2"
-                        android:textSize="14dp"
+                        android:textSize="16sp"
                         android:textColor="@color/material_gray_transparent" />
                     <EditText
                         android:id="@+id/StopTimeEditText"
@@ -97,27 +97,27 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:id="@+id/Project"
-                android:layout_marginTop="15dp" />
+                android:layout_marginTop="14dp" />
             <Toggl.Joey.UI.Views.TogglField
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:id="@+id/Description"
-                android:layout_marginTop="10dp" />
+                android:layout_marginTop="14dp" />
             <Toggl.Joey.UI.Views.EditTimeEntryTagsBit
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:id="@+id/TagsBit"
-                android:layout_marginTop="10dp" />
+                android:layout_marginTop="14dp" />
             <CheckBox
                 android:id="@+id/BillableCheckBox"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:text="@string/CurrentTimeEntryEditBillableUnchecked"
-                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:textSize="16sp"
                 android:textColor="@color/BillableTextColor"
                 android:gravity="center_vertical"
                 android:button="@null"
-                android:layout_marginTop="10dp"
+                android:layout_marginTop="24dp"
                 android:drawableLeft="@drawable/IcBillableGreen"
                 android:drawablePadding="5dp" />
         </LinearLayout>

--- a/Joey/Resources/layout/EditTimeEntryFragment.axml
+++ b/Joey/Resources/layout/EditTimeEntryFragment.axml
@@ -97,17 +97,17 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:id="@+id/Project"
-                android:layout_marginTop="14dp" />
+                android:layout_marginTop="20dp" />
             <Toggl.Joey.UI.Views.TogglField
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:id="@+id/Description"
-                android:layout_marginTop="14dp" />
+                android:layout_marginTop="20dp" />
             <Toggl.Joey.UI.Views.EditTimeEntryTagsBit
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:id="@+id/TagsBit"
-                android:layout_marginTop="14dp" />
+                android:layout_marginTop="20dp" />
             <CheckBox
                 android:id="@+id/BillableCheckBox"
                 android:layout_width="wrap_content"

--- a/Joey/Resources/layout/EditTimeEntryTagsBit.axml
+++ b/Joey/Resources/layout/EditTimeEntryTagsBit.axml
@@ -8,7 +8,6 @@
                 android:id="@+id/EditTimeEntryTagsBitTitle"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="15dp"
                 android:layout_marginBottom="4dp"
                 android:textSize="12sp"
                 android:lines="1"

--- a/Joey/Resources/layout/GroupedEditTimeEntryFragment.axml
+++ b/Joey/Resources/layout/GroupedEditTimeEntryFragment.axml
@@ -27,27 +27,28 @@
             android:layout_marginTop="10dp">
             <Toggl.Joey.UI.Views.TogglField
                 android:layout_width="match_parent"
-                android:layout_height="56dp"
+                android:layout_height="match_parent"
                 android:id="@+id/GroupedEditTimeEntryFragmentProject" />
             <Toggl.Joey.UI.Views.TogglField
                 android:layout_width="match_parent"
-                android:layout_height="56dp"
+				android:layout_height="match_parent"
                 android:id="@+id/GroupedEditTimeEntryFragmentDescription"
-                android:layout_marginTop="10dp" />
+                android:layout_marginTop="14dp" />
             <Toggl.Joey.UI.Views.EditTimeEntryTagsBit
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:id="@+id/GroupedEditTimeEntryFragmentTags" />
+                android:id="@+id/GroupedEditTimeEntryFragmentTags"
+                android:layout_marginTop="14dp" />
             <CheckBox
                 android:id="@+id/GroupedEditTimeEntryFragmentBillableCheckBox"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:text="@string/CurrentTimeEntryEditBillableUnchecked"
-                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:textSize="16sp"
                 android:textColor="@color/BillableTextColor"
                 android:gravity="center_vertical"
                 android:button="@null"
-                android:layout_marginTop="10dp"
+                android:layout_marginTop="24dp"
                 android:drawableLeft="@drawable/IcBillableGreen"
                 android:drawablePadding="5dp" />
         </LinearLayout>

--- a/Joey/Resources/layout/GroupedEditTimeEntryFragment.axml
+++ b/Joey/Resources/layout/GroupedEditTimeEntryFragment.axml
@@ -24,7 +24,7 @@
             android:layout_height="wrap_content"
             android:paddingRight="32dp"
             android:paddingLeft="32dp"
-            android:layout_marginTop="10dp">
+            android:layout_marginTop="15dp">
             <Toggl.Joey.UI.Views.TogglField
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
@@ -33,12 +33,12 @@
                 android:layout_width="match_parent"
 				android:layout_height="match_parent"
                 android:id="@+id/GroupedEditTimeEntryFragmentDescription"
-                android:layout_marginTop="14dp" />
+                android:layout_marginTop="20dp" />
             <Toggl.Joey.UI.Views.EditTimeEntryTagsBit
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:id="@+id/GroupedEditTimeEntryFragmentTags"
-                android:layout_marginTop="14dp" />
+                android:layout_marginTop="20dp" />
             <CheckBox
                 android:id="@+id/GroupedEditTimeEntryFragmentBillableCheckBox"
                 android:layout_width="wrap_content"

--- a/Joey/Resources/layout/TogglField.axml
+++ b/Joey/Resources/layout/TogglField.axml
@@ -10,7 +10,6 @@
                 		android:id="@+id/EditTimeEntryBitTitle"
                         android:layout_width="fill_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="5dp"
                         android:layout_marginBottom="5dp"
                         android:textSize="12sp"
                         android:lines="1"

--- a/Joey/UI/Fragments/GroupedEditTimeEntryFragment.cs
+++ b/Joey/UI/Fragments/GroupedEditTimeEntryFragment.cs
@@ -63,7 +63,7 @@ namespace Toggl.Joey.UI.Fragments
 
             DurationTextView = durationLayout.FindViewById<TextView> (Resource.Id.DurationTextViewTextView);
 
-            Toolbar.SetCustomView (durationLayout, new ActionBar.LayoutParams (ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.MatchParent));
+            Toolbar.SetCustomView (durationLayout, new ActionBar.LayoutParams ((int)GravityFlags.Center));
             Toolbar.SetDisplayShowCustomEnabled (true);
             Toolbar.SetDisplayShowTitleEnabled (false);
 

--- a/Joey/UI/Views/EditTimeEntryTagsBit.cs
+++ b/Joey/UI/Views/EditTimeEntryTagsBit.cs
@@ -71,8 +71,6 @@ namespace Toggl.Joey.UI.Views
                 return;
             }
 
-            return ;
-
             if (tagsView.Count == 0) {
                 EditText.Text = String.Empty;
                 return;


### PR DESCRIPTION
1. Start and end captions are now 16sp
2. Tags green labels now have 2px corner radius
3. Billable text is now 16sp
4. Grouped TE Edit Duration Title is now centered
5. Increased between-the-togglField vertical space as task field is no longer shown
6. Enable tags binding for EditTimeEntryTagsBit

Closing https://github.com/toggl/mobile/issues/653
Closing https://github.com/toggl/mobile/issues/626