### PR TITLE
Fix bulk entries deleting, time entry cell UI when switching activities

### DIFF
--- a/Joey/UI/Views/ListItemSwipeable.cs
+++ b/Joey/UI/Views/ListItemSwipeable.cs
@@ -89,6 +89,10 @@ namespace Toggl.Joey.UI.Views
 
         private void OnScrollAnimationEnd (object sender, EventArgs e)
         {
+            if (WindowVisibility == ViewStates.Gone) {
+                InitSwipeDeleteBg ();
+                return;
+            }
             if (SwipeAnimationEnd != null) {
                 SwipeAnimationEnd (this, EventArgs.Empty);
             }

--- a/Phoebe/Data/Views/GroupedTimeEntriesView.cs
+++ b/Phoebe/Data/Views/GroupedTimeEntriesView.cs
@@ -89,8 +89,11 @@ namespace Toggl.Phoebe.Data.Views
         public async void ConfirmItemRemove ()
         {
             if (removedItem != null) {
+                var rememberId = removedItem.Id;
                 await removedItem.DeleteAsync();
-                removedItem = null;
+                if (rememberId == removedItem.Id) {
+                    removedItem = null;
+                }
             }
         }
 

--- a/Phoebe/Data/Views/GroupedTimeEntriesView.cs
+++ b/Phoebe/Data/Views/GroupedTimeEntriesView.cs
@@ -86,15 +86,16 @@ namespace Toggl.Phoebe.Data.Views
             RemoveTimeEntryGroup (data);
         }
 
-        public async void ConfirmItemRemove ()
+        public void ConfirmItemRemove ()
         {
             if (removedItem != null) {
-                var rememberId = removedItem.Id;
-                await removedItem.DeleteAsync();
-                if (rememberId == removedItem.Id) {
-                    removedItem = null;
-                }
+                DeleteTimeGroup (removedItem);
+                removedItem = null;
             }
+        }
+
+        private async void DeleteTimeGroup (TimeEntryGroup grp) {
+            await grp.DeleteAsync ();
         }
 
         private void OnDataChange (DataChangeMessage msg)

--- a/Phoebe/Data/Views/LogTimeEntriesView.cs
+++ b/Phoebe/Data/Views/LogTimeEntriesView.cs
@@ -90,12 +90,14 @@ namespace Toggl.Phoebe.Data.Views
         public async void ConfirmItemRemove ()
         {
             if (removedItem != null) {
-                var model = new TimeEntryModel (removedItem);
-                await model.DeleteAsync();
-                if (removedItem.Id == model.Id) {
-                    removedItem = null;
-                }
+                DeleteTimeEntry (removedItem);
+                removedItem = null;
             }
+        }
+
+        private async void DeleteTimeEntry(TimeEntryData data) {
+            var model = new TimeEntryModel (removedItem);
+            await model.DeleteAsync ();
         }
 
         private void OnDataChange (DataChangeMessage msg)

--- a/Phoebe/Data/Views/LogTimeEntriesView.cs
+++ b/Phoebe/Data/Views/LogTimeEntriesView.cs
@@ -87,7 +87,7 @@ namespace Toggl.Phoebe.Data.Views
             RemoveEntry (data);
         }
 
-        public async void ConfirmItemRemove ()
+        public void ConfirmItemRemove ()
         {
             if (removedItem != null) {
                 DeleteTimeEntry (removedItem);

--- a/Phoebe/Data/Views/LogTimeEntriesView.cs
+++ b/Phoebe/Data/Views/LogTimeEntriesView.cs
@@ -92,7 +92,9 @@ namespace Toggl.Phoebe.Data.Views
             if (removedItem != null) {
                 var model = new TimeEntryModel (removedItem);
                 await model.DeleteAsync();
-                removedItem = null;
+                if (removedItem.Id == model.Id) {
+                    removedItem = null;
+                }
             }
         }
 


### PR DESCRIPTION
1. Fixes cell disappearing while holding swipe and e.g. pressing start button, then closing the new activity
2. Fixes removing 2+ entries in a row (the last one in the queue is not deleted and being nullified due to no guid check after the await). Fixing https://github.com/toggl/mobile/issues/639 as far as I get the issue & tested it. Both for single / grouped entries.