### PR TITLE
Always Show Timer Button In Toolbar If Main Timer Screen

### DIFF
--- a/Joey/UI/Activities/MainDrawerActivity.cs
+++ b/Joey/UI/Activities/MainDrawerActivity.cs
@@ -298,6 +298,11 @@ namespace Toggl.Joey.UI.Activities
 
         private void OnDrawerListViewItemClick (object sender, ListView.ItemClickEventArgs e)
         {
+            // If tap outside options just close drawer
+            if (e.Id == -1) {
+                DrawerLayout.CloseDrawers ();
+                return;
+            }
 
             // Configure timer component for selected page:
             if (e.Id != DrawerListAdapter.TimerPageId) {

--- a/Joey/UI/Activities/MainDrawerActivity.cs
+++ b/Joey/UI/Activities/MainDrawerActivity.cs
@@ -267,6 +267,7 @@ namespace Toggl.Joey.UI.Activities
                 SupportActionBar.SetTitle (Resource.String.MainDrawerTimer);
                 OpenFragment (trackingFragment.Value);
                 drawerAdapter.ExpandCollapse (DrawerListAdapter.TimerPageId);
+                Timer.HideAction = false;
             }
             SetMenuSelection (drawerAdapter.GetItemPosition (id));
 


### PR DESCRIPTION
The OpenPage() is called from the OnBackPressed(), though the method didn't care about timer showing if back to Main Timer screen
Fixing https://github.com/toggl/mobile/issues/672