### PR TITLE
TogglField Highlight Bottom Line Red When Selected

### DIFF
--- a/Joey/UI/Views/TogglField.cs
+++ b/Joey/UI/Views/TogglField.cs
@@ -32,6 +32,7 @@ namespace Toggl.Joey.UI.Views
 
             text.FocusChange += (sender, e) => {
                 title.Selected = text.HasFocus;
+                Selected = text.HasFocus;
             };
         }
 


### PR DESCRIPTION
Basically, this line of code is trying to implement android:addStatesFromChildren (https://github.com/toggl/mobile/blob/android-redesign/Joey/Resources/layout/TogglField.axm) for the root RelativeLayout view, but with a selected-focus logic pair. Fixes the issue on some devices. 

Though before, all was fine for my test devices (Android 5.0/1), without any code-help. Should continue the testing on devices where the problem persisted (like a @pe0ny device).

Finally closing https://github.com/toggl/mobile/issues/691 (friends with https://github.com/toggl/mobile/pull/705)