### PR TITLE
Recycled DataView Adapter: Display Spinner If Loading (affects Project Screen)

### DIFF
--- a/Joey/UI/Adapters/RecycledDataViewAdapter.cs
+++ b/Joey/UI/Adapters/RecycledDataViewAdapter.cs
@@ -151,7 +151,7 @@ namespace Toggl.Joey.UI.Adapters
         public override int ItemCount
         {
             get {
-                if (dataView.HasMore) {
+                if (dataView.IsLoading || dataView.IsLoading) {
                     return dataView.Count + 1;
                 }
                 return dataView.Count;

--- a/Joey/UI/Adapters/RecycledDataViewAdapter.cs
+++ b/Joey/UI/Adapters/RecycledDataViewAdapter.cs
@@ -151,7 +151,7 @@ namespace Toggl.Joey.UI.Adapters
         public override int ItemCount
         {
             get {
-                if (dataView.IsLoading || dataView.IsLoading) {
+                if (dataView.IsLoading || dataView.HasMore) {
                     return dataView.Count + 1;
                 }
                 return dataView.Count;


### PR DESCRIPTION
Closing https://github.com/toggl/mobile/issues/717
To eliminate “fragile base class” problem: only ProjectListAdapter, LogTimeEntriesAdapter and GroupedTimeEntriesAdapter inherit from the RecycledDataViewAdapter. These 3 are fully tested. 
![screenshot_2015-05-26-23-54-57](https://cloud.githubusercontent.com/assets/720966/7823300/43fcf28e-0403-11e5-8577-55836383b41e.png)