### PR TITLE
Background Line Drawable: Solid Transparent On Samsung Devices

### DIFF
--- a/Joey/Resources/drawable/BackgroundLine.xml
+++ b/Joey/Resources/drawable/BackgroundLine.xml
@@ -4,21 +4,25 @@
             <selector xmlns:android="http://schemas.android.com/apk/res/android">
                  <item android:state_pressed="true">
                     <shape>
+                        <solid android:color="@android:color/transparent" />
                         <stroke android:color="@color/material_red" android:width="1dp"/>
                     </shape>
                  </item>
                  <item android:state_focused="true">
                     <shape>
+                        <solid android:color="@android:color/transparent" />
                         <stroke android:color="@color/material_red" android:width="1dp" />
                     </shape>
                  </item>
                  <item android:state_selected="true">
                     <shape>
+                        <solid android:color="@android:color/transparent" />
                         <stroke android:color="@color/material_red" android:width="1dp" />
                     </shape>
                  </item>
                  <item>
                     <shape>
+                        <solid android:color="@android:color/transparent" />
                         <stroke android:color="@color/material_gray_transparent" android:width="1dp" />
                     </shape>
                  </item>


### PR DESCRIPTION
Android 4.1.1
![screen shot 2015-06-01 at 7 42 17 pm](https://cloud.githubusercontent.com/assets/720966/7917915/6f997cea-0896-11e5-89a8-279750729a50.png)
