### PR TITLE
Revert "Don't delete items when app is syncing."

### DIFF
--- a/Joey/UI/Fragments/LogTimeEntriesListFragment.cs
+++ b/Joey/UI/Fragments/LogTimeEntriesListFragment.cs
@@ -16,7 +16,6 @@ using Toggl.Phoebe;
 using Toggl.Phoebe.Data;
 using Toggl.Phoebe.Data.Utils;
 using Toggl.Phoebe.Data.Views;
-using Toggl.Phoebe.Net;
 using XPlatUtils;
 
 namespace Toggl.Joey.UI.Fragments
@@ -150,12 +149,6 @@ namespace Toggl.Joey.UI.Fragments
 
         public bool CanDismiss (RecyclerView view, int position)
         {
-            // Find a better solution
-            var syncManager = ServiceContainer.Resolve<ISyncManager> ();
-            if (syncManager.IsRunning) {
-                return false;
-            }
-
             var adapter = view.GetAdapter ();
             return (adapter.GetItemViewType (position) == GroupedTimeEntriesAdapter.ViewTypeContent ||
                     adapter.GetItemViewType (position) == LogTimeEntriesAdapter.ViewTypeContent);


### PR DESCRIPTION
Reverts toggl/mobile#740

Later we should check how operations like Delete time entry affects the synced data when it is working.