### PR TITLE
Fixed wrong operation for multiples Add on LogTimeEntriesView.

### DIFF
--- a/Joey/Joey.csproj
+++ b/Joey/Joey.csproj
@@ -69,11 +69,11 @@
     <Reference Include="Xamarin.Android.Support.v7.MediaRouter">
       <HintPath>..\packages\Xamarin.Android.Support.v7.MediaRouter.22.1.1.1\lib\MonoAndroid403\Xamarin.Android.Support.v7.MediaRouter.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.Insights">
-      <HintPath>..\packages\Xamarin.Insights.1.10.2.110\lib\MonoAndroid10\Xamarin.Insights.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.Android.Support.v7.RecyclerView">
       <HintPath>..\packages\Xamarin.Android.Support.v7.RecyclerView.22.1.1.1\lib\MonoAndroid403\Xamarin.Android.Support.v7.RecyclerView.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Insights">
+      <HintPath>..\packages\Xamarin.Insights.1.10.3.111\lib\MonoAndroid10\Xamarin.Insights.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Joey/packages.config
+++ b/Joey/packages.config
@@ -7,5 +7,5 @@
   <package id="Xamarin.Android.Support.v7.MediaRouter" version="22.1.1.1" targetFramework="MonoAndroid43" />
   <package id="Xamarin.Android.Support.v7.RecyclerView" version="22.1.1.1" targetFramework="MonoAndroid43" />
   <package id="Xamarin.GooglePlayServices" version="22.0.0.2" targetFramework="MonoAndroid43" />
-  <package id="Xamarin.Insights" version="1.10.2.110" targetFramework="MonoAndroid43" />
+  <package id="Xamarin.Insights" version="1.10.3.111" targetFramework="MonoAndroid43" />
 </packages>


### PR DESCRIPTION
The current flow related with LogTimeEntriesView and recyclerView could be described like this:

- Receive and classify the event:
https://github.com/toggl/mobile/blob/master/Phoebe/Data/Views/LogTimeEntriesView.cs#L109

- Process this event and generate the corresponding action (Add item at position 1, Delete item at position 3, Move item to position 2, etc.)
https://github.com/toggl/mobile/blob/master/Phoebe/Data/Views/LogTimeEntriesView.cs#L130

- Update the list of items: This list contains data objects that are an exact representation of what is showed by the recyclerView.
https://github.com/toggl/mobile/blob/master/Phoebe/Data/Views/LogTimeEntriesView.cs#L799

- Load data related with this event: If we have to show a new TimeEntry, in this moment we load the project, tags, etc.
https://github.com/toggl/mobile/blob/anton-recyclerviewadd/Phoebe/Data/Views/LogTimeEntriesView.cs#L815

- And dispatch an ObservableCollection event:
https://github.com/toggl/mobile/blob/anton-recyclerviewadd/Phoebe/Data/Views/LogTimeEntriesView.cs#L877







