### PR TITLE
Disable ShowWhenLocked flag and DisableKeyguard permission.

### DIFF
--- a/Joey/Properties/AndroidManifest.xml
+++ b/Joey/Properties/AndroidManifest.xml
@@ -4,7 +4,6 @@
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.GET_ACCOUNTS" />
-	<uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
 	<uses-permission android:name="android.permission.WAKE_LOCK" />
 	<uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 	<permission android:name="com.toggl.timer.permission.C2D_MESSAGE" android:protectionLevel="signature" />

--- a/Joey/UI/Activities/BaseActivity.cs
+++ b/Joey/UI/Activities/BaseActivity.cs
@@ -89,8 +89,6 @@ namespace Toggl.Joey.UI.Activities
         protected sealed override void OnCreate (Bundle savedInstanceState)
         {
             base.OnCreate (savedInstanceState);
-            Window windowManager = Window;
-            windowManager.AddFlags (WindowManagerFlags.ShowWhenLocked); // to launch app from lock screen widget
 
             if (!StartAuthActivity ()) {
                 OnCreateActivity (savedInstanceState);


### PR DESCRIPTION
App is brought to front when an entry is started and when the phone is unlocked the app comes to focus.
Closes #725 