### PR TITLE
Fix RecyclerView holder position error on continue

### DIFF
--- a/Joey/UI/Adapters/LogTimeEntriesAdapter.cs
+++ b/Joey/UI/Adapters/LogTimeEntriesAdapter.cs
@@ -101,10 +101,10 @@ namespace Toggl.Joey.UI.Adapters
 
             // Trick on view to show a better
             // visual reaction to press Play btn
-            for (int i = 0; i < holderList.Count; i++) {
-                var holder = holderList [i] as TimeEntryListItemHolder;
+            foreach (var item in holderList) {
+                var holder = item as TimeEntryListItemHolder;
                 if (holder != null) {
-                    if (holder.DataSource.State == TimeEntryState.Running) {
+                    if (holder.DataSource.State == TimeEntryState.Running && holder.AdapterPosition != -1) {
                         holder.DataSource.TimeEntryData.State = TimeEntryState.Finished;
                         BindHolder (holder, holder.AdapterPosition);
                     }


### PR DESCRIPTION
holderList contains duplicate running item when changing from GroupedEntries mode with a running time entry.
Also, GetViewHolder function fills holderList up with cluttered data on continueing entries.
Closes #745 