### PR TITLE
TE Activity: close if no data is restored from the intent

### DIFF
--- a/Joey/UI/Activities/EditTimeEntryActivity.cs
+++ b/Joey/UI/Activities/EditTimeEntryActivity.cs
@@ -31,6 +31,9 @@ namespace Toggl.Joey.UI.Activities
             TimeEntryData timeEntry = null;
             if (timeEntryList.Count > 0) {
                 timeEntry = timeEntryList[0];
+            } else {
+                OnBackPressed ();
+                return;
             }
 
             var isGrouped = Intent.Extras.GetBoolean (IsGrouped, false);


### PR DESCRIPTION
Fixing:
```
System.NullReferenceExceptionObject reference not set to an instance of an object
  at Toggl.Joey.UI.Fragments.EditTimeEntryFragment..ctor (Toggl.Phoebe.Data.DataObjects.TimeEntryData timeEntry) [0x00000] in <filename unknown>:0 
  at Toggl.Joey.UI.Activities.EditTimeEntryActivity+<OnCreateActivity>c__async0.MoveNext () [0x00000] in <filename unknown>:0 
```

Tested with "don't keep activities" and app foreground / background states