### PR TITLE
Avoid wrong index on CanDissmis from swipe listener.

### DIFF
--- a/Joey/UI/Utils/SwipeDismissTouchListener.cs
+++ b/Joey/UI/Utils/SwipeDismissTouchListener.cs
@@ -97,12 +97,17 @@ namespace Toggl.Joey.UI.Utils
                     downX = motionEvent.RawX;
                     downY = motionEvent.RawY;
                     downPosition = recyclerView.GetChildPosition (downView);
-                    if (callbacks.CanDismiss (recyclerView, downPosition)) {
-                        velocityTracker = VelocityTracker.Obtain ();
-                        velocityTracker.AddMovement (motionEvent);
+                    if (downPosition != -1) {
+                        if (callbacks.CanDismiss (recyclerView, downPosition)) {
+                            velocityTracker = VelocityTracker.Obtain ();
+                            velocityTracker.AddMovement (motionEvent);
+                        } else {
+                            downView = null;
+                        }
                     } else {
                         downView = null;
                     }
+
                 }
                 return false;
 


### PR DESCRIPTION
Fixed wrong on index on CanDismiss method that come from SwipeDismissTouchListener.