### PR TITLE
SQLiteConnection: FullMutex (Serialized mode analog), put/delete locks

### DIFF
--- a/Phoebe/Data/SqliteDataStore.cs
+++ b/Phoebe/Data/SqliteDataStore.cs
@@ -241,13 +241,15 @@ namespace Toggl.Phoebe.Data
             public Context (SqliteDataStore store, string dbPath)
             {
                 this.store = store;
-                conn = new SQLiteConnection (dbPath);
+                conn = new SQLiteConnection (dbPath, SQLiteOpenFlags.Create | SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.FullMutex);
             }
 
             public T Put<T> (T obj)
             where T : new()
             {
-                conn.InsertOrReplace (obj);
+                lock (conn) {
+                    conn.InsertOrReplace (obj);
+                }
 
                 // Schedule message to be sent about this update post transaction
                 messages.Add (new DataChangeMessage (store, obj, DataAction.Put));
@@ -257,7 +259,10 @@ namespace Toggl.Phoebe.Data
 
             public bool Delete (object obj)
             {
-                var count = conn.Delete (obj);
+                int count;
+                lock (conn) {
+                    count = conn.Delete (obj);
+                }
                 var success = count > 0;
 
                 // Schedule message to be sent about this delete post transaction

--- a/Phoebe/Data/SqliteDataStore.cs
+++ b/Phoebe/Data/SqliteDataStore.cs
@@ -241,15 +241,13 @@ namespace Toggl.Phoebe.Data
             public Context (SqliteDataStore store, string dbPath)
             {
                 this.store = store;
-                conn = new SQLiteConnection (dbPath, SQLiteOpenFlags.Create | SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.FullMutex);
+                conn = new SQLiteConnection (dbPath);
             }
 
             public T Put<T> (T obj)
             where T : new()
             {
-                lock (conn) {
-                    conn.InsertOrReplace (obj);
-                }
+                conn.InsertOrReplace (obj);
 
                 // Schedule message to be sent about this update post transaction
                 messages.Add (new DataChangeMessage (store, obj, DataAction.Put));
@@ -259,10 +257,7 @@ namespace Toggl.Phoebe.Data
 
             public bool Delete (object obj)
             {
-                int count;
-                lock (conn) {
-                    count = conn.Delete (obj);
-                }
+                var count = conn.Delete (obj);
                 var success = count > 0;
 
                 // Schedule message to be sent about this delete post transaction

--- a/Phoebe/Net/AuthManager.cs
+++ b/Phoebe/Net/AuthManager.cs
@@ -25,6 +25,13 @@ namespace Toggl.Phoebe.Net
 
         public AuthManager ()
         {
+            Init ();
+
+            var bus = ServiceContainer.Resolve<MessageBus> ();
+            subscriptionDataChange = bus.Subscribe<DataChangeMessage> (OnDataChange);
+        }
+            
+        public async void Init() {
             var credStore = ServiceContainer.Resolve<ISettingsStore> ();
             try {
                 if (credStore.UserId.HasValue) {
@@ -32,7 +39,7 @@ namespace Toggl.Phoebe.Net
                         Id = credStore.UserId.Value,
                     };
                     // Load full user data:
-                    ReloadUser ();
+                    await ReloadUser ();
                 }
                 Token = credStore.ApiToken;
                 IsAuthenticated = !String.IsNullOrEmpty (Token);
@@ -41,13 +48,9 @@ namespace Toggl.Phoebe.Net
                 credStore.UserId = null;
                 credStore.ApiToken = null;
             }
-
-            // Listen for global data changes
-            var bus = ServiceContainer.Resolve<MessageBus> ();
-            subscriptionDataChange = bus.Subscribe<DataChangeMessage> (OnDataChange);
         }
 
-        private async void ReloadUser ()
+        private async Task ReloadUser ()
         {
             if (User == null) {
                 return;


### PR DESCRIPTION
Issue: https://github.com/toggl/mobile/issues/785
I think the issue reason is multiple threads accessing SQLite store at once, fullMutex flag and base locks _should_ fix it. 
@monday8am @taavirehemagi need your opinion
http://forums.xamarin.com/discussion/549/sqlite-net-and-multiple-threads