### PR TITLE
Added async init interface and implemented on AuthManager service.Tries to improve #794 PR

### DIFF
--- a/Joey/AndroidApp.cs
+++ b/Joey/AndroidApp.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
 using Android.Net;
@@ -28,7 +29,7 @@ namespace Toggl.Joey
                Value = "@integer/google_play_services_version")]
     class AndroidApp : Application, IPlatformInfo
     {
-        private bool componentsInitialized = false;
+        private bool componentsInitialized;
         private Stopwatch startTimeMeasure = Stopwatch.StartNew();
 
         public AndroidApp () : base ()
@@ -39,21 +40,18 @@ namespace Toggl.Joey
         {
         }
 
-        public override void OnCreate ()
+        public async override void OnCreate ()
         {
             base.OnCreate ();
 
-            RegisterComponents ();
+            await RegisterComponentsAsync ();
             InitializeStartupComponents ();
         }
 
-        private void RegisterComponents ()
+        private async Task RegisterComponentsAsync ()
         {
             // Register platform service.
             ServiceContainer.Register<IPlatformInfo> (this);
-
-            // Register Phoebe services.
-            Services.Register ();
 
             // Register Joey components:
             ServiceContainer.Register<ILogger> (() => new Logger ());
@@ -81,6 +79,9 @@ namespace Toggl.Joey
             });
             ServiceContainer.Register<ITracker> (() => new Tracker (this));
             ServiceContainer.Register<INetworkPresence> (() => new NetworkPresence (Context, (ConnectivityManager)GetSystemService (ConnectivityService)));
+
+            // Register Phoebe services.
+            await Services.RegisterAsync ();
         }
 
         private void InitializeStartupComponents ()
@@ -136,6 +137,8 @@ namespace Toggl.Joey
             get { return PackageManager.GetPackageInfo (PackageName, 0).VersionName; }
         }
 
+        // Property to match with the IPlatformInfo
+        // interface. This interface is implemented by iOS and Android.
         public bool IsWidgetAvailable
         {
             get { return true; }

--- a/Joey/UI/Activities/BaseActivity.cs
+++ b/Joey/UI/Activities/BaseActivity.cs
@@ -75,7 +75,6 @@ namespace Toggl.Joey.UI.Activities
                 Finish ();
                 return true;
             }
-
             return false;
         }
 

--- a/Joey/UI/Activities/LoginActivity.cs
+++ b/Joey/UI/Activities/LoginActivity.cs
@@ -287,7 +287,7 @@ namespace Toggl.Joey.UI.Activities
             var authManager = ServiceContainer.Resolve<AuthManager> ();
             AuthResult authRes;
             try {
-                authRes = await authManager.Authenticate (EmailEditText.Text, PasswordEditText.Text);
+                authRes = await authManager.AuthenticateAsync (EmailEditText.Text, PasswordEditText.Text);
             } catch (InvalidOperationException ex) {
                 var log = ServiceContainer.Resolve<ILogger> ();
                 log.Info (LogTag, ex, "Failed to authenticate user with password.");
@@ -317,7 +317,7 @@ namespace Toggl.Joey.UI.Activities
             var authManager = ServiceContainer.Resolve<AuthManager> ();
             AuthResult authRes;
             try {
-                authRes = await authManager.Signup (EmailEditText.Text, PasswordEditText.Text);
+                authRes = await authManager.SignupAsync (EmailEditText.Text, PasswordEditText.Text);
             } catch (InvalidOperationException ex) {
                 var log = ServiceContainer.Resolve<ILogger> ();
                 log.Info (LogTag, ex, "Failed to signup user with password.");
@@ -567,14 +567,14 @@ namespace Toggl.Joey.UI.Activities
                         activity = Activity as LoginActivity;
                         if (activity != null && activity.CurrentMode == Mode.Signup) {
                             // Signup with Google
-                            var authRes = await authManager.SignupWithGoogle (token);
+                            var authRes = await authManager.SignupWithGoogleAsync (token);
                             if (authRes != AuthResult.Success) {
                                 ClearGoogleToken (ctx, token);
                                 activity.ShowAuthError (Email, authRes, Mode.Signup, googleAuth: true);
                             }
                         } else {
                             // Authenticate client
-                            var authRes = await authManager.AuthenticateWithGoogle (token);
+                            var authRes = await authManager.AuthenticateWithGoogleAsync (token);
                             if (authRes != AuthResult.Success) {
                                 ClearGoogleToken (ctx, token);
                                 activity.ShowAuthError (Email, authRes, Mode.Login, googleAuth: true);

--- a/Phoebe/IAsyncInitialization.cs
+++ b/Phoebe/IAsyncInitialization.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+
+namespace Toggl.Phoebe
+{
+    /// <summary>
+    /// Marks a type as requiring asynchronous initialization and provides the result of that initialization.
+    /// </summary>
+    public interface IAsyncInitialization
+    {
+        /// <summary>
+        /// The result of the asynchronous initialization of this instance.
+        /// </summary>
+        Task Initialization { get; }
+    }
+}
+

--- a/Phoebe/Services.cs
+++ b/Phoebe/Services.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Toggl.Phoebe.Data;
 using Toggl.Phoebe.Data.Json.Converters;
 using Toggl.Phoebe.Logging;
@@ -9,11 +10,11 @@ namespace Toggl.Phoebe
 {
     public static class Services
     {
-        public static void Register ()
+        public async static Task RegisterAsync ()
         {
             ServiceContainer.Register<MessageBus> ();
             ServiceContainer.Register<UpgradeManger> ();
-            ServiceContainer.Register<AuthManager> ();
+
             ServiceContainer.Register<ActiveTimeEntryManager> ();
             ServiceContainer.Register<DataCache> ();
             ServiceContainer.Register<ForeignRelationManager> ();
@@ -31,9 +32,17 @@ namespace Toggl.Phoebe
             ServiceContainer.Register<ITogglClient> (() => new TogglRestClient (Build.ApiUrl));
             ServiceContainer.Register<IReportsClient> (() => new ReportsRestClient (Build.ReportsApiUrl));
 
+            // Asynchronous Initialization Pattern
+            // as described at http://blog.stephencleary.com/2013/01/async-oop-2-constructors.html
+            var authManagerServ = new AuthManager ();
+            ServiceContainer.Register<AuthManager> (authManagerServ);
+
             RegisterJsonConverters ();
 
             ServiceContainer.Register<LoggerUserManager> ();
+
+            // initialise async services.
+            await authManagerServ.Initialization;
         }
 
         private static void RegisterJsonConverters ()

--- a/Ross/AppDelegate.cs
+++ b/Ross/AppDelegate.cs
@@ -15,6 +15,7 @@ using Toggl.Ross.Views;
 using UIKit;
 using XPlatUtils;
 using Xamarin;
+using System.Threading.Tasks;
 
 namespace Toggl.Ross
 {
@@ -28,12 +29,13 @@ namespace Toggl.Ross
         private int systemVersion;
         private const int minVersionWidget = 7;
 
-        public override bool FinishedLaunching (UIApplication application, NSDictionary launchOptions)
+        public async override bool FinishedLaunching (UIApplication application, NSDictionary launchOptions)
         {
             var versionString = UIDevice.CurrentDevice.SystemVersion;
             systemVersion = System.Convert.ToInt32 ( versionString.Split ( new [] {"."}, System.StringSplitOptions.None)[0]);
 
-            RegisterComponents ();
+            // wait for component initialisation.
+            await RegisterComponentsAsync ();
 
             var signIn = Google.Plus.SignIn.SharedInstance;
             signIn.ClientId = Build.GoogleOAuthClientId;
@@ -103,12 +105,10 @@ namespace Toggl.Ross
             }
         }
 
-        private void RegisterComponents ()
+        private async Task RegisterComponentsAsync ()
         {
             // Register platform info first.
             ServiceContainer.Register<IPlatformInfo> (this);
-
-            Services.Register ();
 
             // Override default implementation
             ServiceContainer.Register<ITimeProvider> (() => new NSTimeProvider ());
@@ -140,6 +140,9 @@ namespace Toggl.Ross
             ServiceContainer.Register<INetworkPresence> (() => new NetworkPresence ());
             ServiceContainer.Register<NetworkIndicatorManager> ();
             ServiceContainer.Register<TagChipCache> ();
+
+            // Register Phoebe services async
+            await Services.RegisterAsync ();
         }
 
         public static TogglWindow TogglWindow


### PR DESCRIPTION
This PR tries to improve the solution applied at #794 PR.

Previous to this PR, service registration was not an async operation. Now the registration method returns a Task with the corresponding benefits. 

In case of AuthManager, the init process is divided in two parts, one sync and another async and is user a Initialisation pattern. Not the best way but the more adaptable to rest of the code.