### PR TITLE
IndexOfBound inside RecyclerView fixed.

### DIFF
--- a/Joey/UI/Adapters/LogTimeEntriesAdapter.cs
+++ b/Joey/UI/Adapters/LogTimeEntriesAdapter.cs
@@ -61,10 +61,10 @@ namespace Toggl.Joey.UI.Adapters
                 if (e.NewItems.Count == 1) {
 
                     // If new TE is started,
-                    // move scroll to top position
-                    if (e.NewStartingIndex == 1) {
-                        Owner.SmoothScrollToPosition (0);
-                    }
+                    // we should move the scroll to top position
+                    // Owner.SmoothScrollToPosition (0);
+                    // but in some special cases, this movement breaks
+                    // RecyclerView layout. Under investigation.
 
                     NotifyItemInserted (e.NewStartingIndex);
                 } else {

--- a/Joey/UI/Fragments/LogTimeEntriesListFragment.cs
+++ b/Joey/UI/Fragments/LogTimeEntriesListFragment.cs
@@ -104,6 +104,10 @@ namespace Toggl.Joey.UI.Fragments
                 subscriptionSettingChanged = null;
             }
 
+            // Remove calls to hide Undo bar.
+            handler.RemoveCallbacksAndMessages (null);
+            handler.Dispose ();
+
             ReleaseRecyclerView ();
 
             base.OnDestroyView ();

--- a/Phoebe/Data/Views/TimeEntriesCollectionView.cs
+++ b/Phoebe/Data/Views/TimeEntriesCollectionView.cs
@@ -217,7 +217,7 @@ namespace Toggl.Phoebe.Data.Views
             if (timeEntryHolder == null) {
                 return;
             }
-            Console.WriteLine ("startedddddd!!!! : " + timeEntryHolder.TimeEntryData.Id);
+
             await TimeEntryModel.ContinueTimeEntryDataAsync (timeEntryHolder.TimeEntryData);
 
             // Ping analytics

--- a/Phoebe/Data/Views/TimeEntriesCollectionView.cs
+++ b/Phoebe/Data/Views/TimeEntriesCollectionView.cs
@@ -210,16 +210,28 @@ namespace Toggl.Phoebe.Data.Views
         #endregion
 
         #region TimeEntry operations
-        public async void ContinueTimeEntry (TimeEntryHolder timeEntryHolder)
+        public async void ContinueTimeEntry (int index)
         {
+            // Get data holder
+            var timeEntryHolder = GetHolderFromIndex (index);
+            if (timeEntryHolder == null) {
+                return;
+            }
+            Console.WriteLine ("startedddddd!!!! : " + timeEntryHolder.TimeEntryData.Id);
             await TimeEntryModel.ContinueTimeEntryDataAsync (timeEntryHolder.TimeEntryData);
 
             // Ping analytics
             ServiceContainer.Resolve<ITracker> ().SendTimerStartEvent (TimerStartSource.AppContinue);
         }
 
-        public async void StopTimeEntry (TimeEntryHolder timeEntryHolder)
+        public async void StopTimeEntry (int index)
         {
+            // Get data holder
+            var timeEntryHolder = GetHolderFromIndex (index);
+            if (timeEntryHolder == null) {
+                return;
+            }
+
             await TimeEntryModel.StopAsync (timeEntryHolder.TimeEntryData);
 
             // Ping analytics
@@ -236,15 +248,21 @@ namespace Toggl.Phoebe.Data.Views
             }
         }
 
-        public async void RemoveItemWithUndo (TimeEntryHolder holder)
+        public async void RemoveItemWithUndo (int index)
         {
+            // Get data holder
+            var timeEntryHolder = GetHolderFromIndex (index);
+            if (timeEntryHolder == null) {
+                return;
+            }
+
             // Remove previous if exists
             RemoveItemPermanently (LastRemovedItem);
-            if (holder.State == TimeEntryState.Running) {
-                await TimeEntryModel.StopAsync (holder.TimeEntryData);
+            if (timeEntryHolder.State == TimeEntryState.Running) {
+                await TimeEntryModel.StopAsync (timeEntryHolder.TimeEntryData);
             }
-            LastRemovedItem = holder;
-            RemoveTimeEntryHolder (holder);
+            LastRemovedItem = timeEntryHolder;
+            RemoveTimeEntryHolder (timeEntryHolder);
         }
 
         public void ConfirmItemRemove ()
@@ -264,6 +282,16 @@ namespace Toggl.Phoebe.Data.Views
             } else {
                 await TimeEntryModel.DeleteTimeEntryDataAsync (holder.TimeEntryDataList.First ());
             }
+        }
+
+        private TimeEntryHolder GetHolderFromIndex (int index)
+        {
+            if (index == -1 || index > ItemCollection.Count - 1) {
+                return null;
+            }
+
+            var holder = ItemCollection [index] as TimeEntryHolder;
+            return holder;
         }
 
         protected virtual void AddTimeEntryHolder (TimeEntryHolder holder)

--- a/Phoebe/Data/Views/WorkspaceProjectsView.cs
+++ b/Phoebe/Data/Views/WorkspaceProjectsView.cs
@@ -22,7 +22,8 @@ namespace Toggl.Phoebe.Data.Views
         private int displayTaskForProjectPosition;
 
         private Project displayingTaskForProject;
-        public Project DisplayingTaskForProject {
+        public Project DisplayingTaskForProject
+        {
             get {
                 return displayingTaskForProject;
             }


### PR DESCRIPTION
Error simulation: Load 12 - 13 items at first time, set scroll in top position and press play.

After a long searching, the simplest solution is to eliminate the scroll movement before a new item is added. Seems to be the ```NotifyItemInserted``` method is called when the recycler view hasn't calculated the layout. More info about this bug and different situations: 
https://code.google.com/p/android/issues/detail?id=77846

We'll lose some usability to find a suitable solution.