### PR TITLE
Startup sync on Android app (MainDrawerActivity). Closes #813

### DIFF
--- a/Joey/UI/Activities/MainDrawerActivity.cs
+++ b/Joey/UI/Activities/MainDrawerActivity.cs
@@ -129,6 +129,9 @@ namespace Toggl.Joey.UI.Activities
                     pageStack.AddRange (arr);
                 }
             }
+
+            // Make sure that the user will see newest data when they start the activity
+            ServiceContainer.Resolve<ISyncManager> ().Run ();
         }
 
         private void OnUserChangedEvent (object sender, PropertyChangedEventArgs args)


### PR DESCRIPTION
Missing startup sync on Android. Fixes #813