### PR TITLE
Try to fix IndexOfBound bug on RecyclerView.

### DIFF
--- a/Joey/UI/Adapters/LogTimeEntriesAdapter.cs
+++ b/Joey/UI/Adapters/LogTimeEntriesAdapter.cs
@@ -62,13 +62,17 @@ namespace Toggl.Joey.UI.Adapters
 
                     // If new TE is started,
                     // we should move the scroll to top position
-                    // Owner.SmoothScrollToPosition (0);
-                    // but in some special cases, this movement breaks
-                    // RecyclerView layout. Under investigation.
+                    Owner.SmoothScrollToPosition (0);
 
-                    NotifyItemInserted (e.NewStartingIndex);
+                    // After some investigation, this action breaks
+                    // RecyclerView layout. Under investigation.
+                    // For the moment, the NotifyItemRangeInserted will be
+                    // replaced by the generic NotifyDataSetChanged.
+                    // NotifyItemInserted (e.NewStartingIndex);
+                    NotifyDataSetChanged ();
                 } else {
-                    NotifyItemRangeInserted (e.NewStartingIndex, e.NewItems.Count);
+                    //NotifyItemRangeInserted (e.NewStartingIndex, e.NewItems.Count);
+                    NotifyDataSetChanged ();
                 }
             }
 


### PR DESCRIPTION
Try to fix #799

After long investigation and testing, we think that the RecyclerView breaks its layout when a new item is notified in the Adapter (NotifyItemInserted, NotifyItemRangeInserted). The bug appears when this notification is done and at the same time, the app is showing the loader (the bottom loader is showed to load more items).

In the future, the way to add the loader cell (DataView.Count + 1 trick) should be revised. With this solution, the Add animation is missing but the app still gains in stability. 
