### PR TITLE
Fast fix to layout issue in main list screen. closes #860

### DIFF
--- a/Joey/Resources/layout/LogTimeEntriesListFragment.axml
+++ b/Joey/Resources/layout/LogTimeEntriesListFragment.axml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/logCoordinatorLayout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:fitsSystemWindows="true">
+    android:layout_height="match_parent">
     <android.support.v7.widget.RecyclerView
         android:id="@+id/LogRecyclerView"
         android:layout_width="match_parent"


### PR DESCRIPTION
error on LogTimeEntriesFragment layout.