### PR TITLE
Fix bug of comparison of Dates with Date.MinValue. closes #862

### DIFF
--- a/Joey/AndroidApp.cs
+++ b/Joey/AndroidApp.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
 using Android.Net;
@@ -40,18 +39,21 @@ namespace Toggl.Joey
         {
         }
 
-        public async override void OnCreate ()
+        public override void OnCreate ()
         {
             base.OnCreate ();
 
-            await RegisterComponentsAsync ();
+            RegisterComponents ();
             InitializeStartupComponents ();
         }
 
-        private async Task RegisterComponentsAsync ()
+        private void RegisterComponents ()
         {
             // Register platform service.
             ServiceContainer.Register<IPlatformInfo> (this);
+
+            // Register Phoebe services.
+            Services.Register ();
 
             // Register Joey components:
             ServiceContainer.Register<ITimeProvider> (() => new DefaultTimeProvider ());
@@ -80,9 +82,6 @@ namespace Toggl.Joey
             });
             ServiceContainer.Register<ITracker> (() => new Tracker (this));
             ServiceContainer.Register<INetworkPresence> (() => new NetworkPresence (Context, (ConnectivityManager)GetSystemService (ConnectivityService)));
-
-            // Register Phoebe services.
-            await Services.RegisterAsync ();
         }
 
         private void InitializeStartupComponents ()

--- a/Joey/UI/Adapters/GroupedEditAdapter.cs
+++ b/Joey/UI/Adapters/GroupedEditAdapter.cs
@@ -93,7 +93,7 @@ namespace Toggl.Joey.UI.Adapters
 
         private static TimeSpan GetDuration (TimeEntryData data, DateTime now)
         {
-            if (data.StartTime == DateTime.MinValue) {
+            if (data.StartTime.IsMinValue ()) {
                 return TimeSpan.Zero;
             }
 

--- a/Joey/UI/Adapters/LogTimeEntriesAdapter.cs
+++ b/Joey/UI/Adapters/LogTimeEntriesAdapter.cs
@@ -69,10 +69,9 @@ namespace Toggl.Joey.UI.Adapters
                     // For the moment, the NotifyItemRangeInserted will be
                     // replaced by the generic NotifyDataSetChanged.
                     NotifyItemInserted (e.NewStartingIndex);
-                    // NotifyDataSetChanged ();
                 } else {
-                    NotifyItemRangeInserted (e.NewStartingIndex, e.NewItems.Count);
-                    // NotifyDataSetChanged ();
+                    // NotifyItemRangeInserted (e.NewStartingIndex, e.NewItems.Count);
+                    NotifyDataSetChanged ();
                 }
             }
 

--- a/Joey/UI/Components/TimerComponent.cs
+++ b/Joey/UI/Components/TimerComponent.cs
@@ -110,7 +110,7 @@ namespace Toggl.Joey.UI.Components
             var data = ActiveTimeEntryData;
             if (data != null) {
                 if (backingActiveTimeEntry == null) {
-                    backingActiveTimeEntry = (ITimeEntryModel)new TimeEntryModel (data);
+                    backingActiveTimeEntry = new TimeEntryModel (data);
                 } else {
                     backingActiveTimeEntry.Data = data;
                     shouldRebind = false;

--- a/Joey/UI/Fragments/BaseEditTimeEntryFragment.cs
+++ b/Joey/UI/Fragments/BaseEditTimeEntryFragment.cs
@@ -178,7 +178,7 @@ namespace Toggl.Joey.UI.Fragments
             }
 
             DateTime startTime;
-            var useTimer = TimeEntry.StartTime == DateTime.MinValue;
+            var useTimer = TimeEntry.StartTime.IsMinValue ();
             if (useTimer) {
                 startTime = Time.Now;
 
@@ -215,7 +215,7 @@ namespace Toggl.Joey.UI.Fragments
                 StopTimeEditText.Visibility = ViewStates.Visible;
             } else {
                 StopTimeEditText.Text = Time.Now.ToDeviceTimeString ();
-                if (TimeEntry.StartTime == DateTime.MinValue || TimeEntry.State == TimeEntryState.Running) {
+                if (TimeEntry.StartTime.IsMinValue () || TimeEntry.State == TimeEntryState.Running) {
                     StopTimeEditText.Visibility = ViewStates.Invisible;
                     StopTimeEditLabel.Visibility = ViewStates.Invisible;
                 } else {

--- a/Joey/UI/Fragments/ChangeTimeEntryStartTimeDialogFragment.cs
+++ b/Joey/UI/Fragments/ChangeTimeEntryStartTimeDialogFragment.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Toggl.Phoebe;
 using Toggl.Phoebe.Analytics;
 using Toggl.Phoebe.Data.Models;
 using XPlatUtils;
@@ -28,7 +29,7 @@ namespace Toggl.Joey.UI.Fragments
         protected override DateTime GetInitialDate ()
         {
             var date = Toggl.Phoebe.Time.Now;
-            if (Model != null && Model.StartTime != DateTime.MinValue) {
+            if (Model != null && !Model.StartTime.IsMinValue ()) {
                 date = Model.StartTime.ToLocalTime ().Date;
             }
             return date;
@@ -37,7 +38,7 @@ namespace Toggl.Joey.UI.Fragments
         protected override DateTime GetInitialTime ()
         {
             var time = Toggl.Phoebe.Time.Now;
-            if (Model != null && Model.StartTime != DateTime.MinValue) {
+            if (Model != null && !Model.StartTime.IsMinValue ()) {
                 time = Model.StartTime.ToLocalTime ();
             }
             return time;

--- a/Phoebe/Data/Json/Converters/TimeEntryJsonConverter.cs
+++ b/Phoebe/Data/Json/Converters/TimeEntryJsonConverter.cs
@@ -51,7 +51,7 @@ namespace Toggl.Phoebe.Data.Json.Converters
 
             // Calculate time entry duration
             TimeSpan duration;
-            if (data.StartTime == DateTime.MinValue) {
+            if (data.StartTime.IsMinValue ()) {
                 duration = TimeSpan.Zero;
             } else {
                 duration = (data.StopTime ?? now) - data.StartTime;

--- a/Phoebe/Data/Models/TimeEntryModel.cs
+++ b/Phoebe/Data/Models/TimeEntryModel.cs
@@ -243,7 +243,7 @@ namespace Toggl.Phoebe.Data.Models
 
         public static TimeSpan GetDuration (TimeEntryData data, DateTime now)
         {
-            if (data.StartTime == DateTime.MinValue) {
+            if (data.StartTime.IsMinValue ()) {
                 return TimeSpan.Zero;
             }
 
@@ -362,7 +362,7 @@ namespace Toggl.Phoebe.Data.Models
             if (Data.State != TimeEntryState.New) {
                 throw new InvalidOperationException (String.Format ("Cannot start a time entry in {0} state.", Data.State));
             }
-            if (Data.StartTime != DateTime.MinValue || Data.StopTime.HasValue) {
+            if (!Data.StartTime.IsMinValue () || Data.StopTime.HasValue) {
                 throw new InvalidOperationException ("Cannot start tracking time entry with start/stop time set already.");
             }
 
@@ -463,7 +463,7 @@ namespace Toggl.Phoebe.Data.Models
             if (Data.State != TimeEntryState.New) {
                 throw new InvalidOperationException (String.Format ("Cannot store a time entry in {0} state.", Data.State));
             }
-            if (Data.StartTime == DateTime.MinValue || Data.StopTime == null) {
+            if (Data.StartTime.IsMinValue () || Data.StopTime == null) {
                 throw new InvalidOperationException ("Cannot store time entry with start/stop time not set.");
             }
 

--- a/Phoebe/Data/Views/WidgetDataView.cs
+++ b/Phoebe/Data/Views/WidgetDataView.cs
@@ -107,7 +107,7 @@ namespace Toggl.Phoebe.Data.Views
 
         private TimeSpan GetDuration (DateTime startTime, DateTime stopTime)
         {
-            if (startTime == DateTime.MinValue) {
+            if (startTime.IsMinValue ()) {
                 return TimeSpan.Zero;
             }
 

--- a/Phoebe/DateTimeExtensions.cs
+++ b/Phoebe/DateTimeExtensions.cs
@@ -67,6 +67,11 @@ namespace Toggl.Phoebe
         {
             return AbsoluteStart (dateTime).AddDays (1).AddTicks (-1);
         }
+
+        public static bool IsMinValue (this DateTime dateTime)
+        {
+            return (dateTime - DateTime.MinValue).Ticks < 10;
+        }
     }
 }
 

--- a/Phoebe/Phoebe.Desktop.csproj
+++ b/Phoebe/Phoebe.Desktop.csproj
@@ -32,6 +32,12 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="Xamarin.Insights">
+      <HintPath>..\packages\Xamarin.Insights.1.10.4.112\lib\portable-win+net40\Xamarin.Insights.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Dataflow">
+      <HintPath>..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>

--- a/Phoebe/Services.cs
+++ b/Phoebe/Services.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 using Toggl.Phoebe.Data;
 using Toggl.Phoebe.Data.Json.Converters;
 using Toggl.Phoebe.Logging;
@@ -10,11 +9,11 @@ namespace Toggl.Phoebe
 {
     public static class Services
     {
-        public async static Task RegisterAsync ()
+        public static void Register ()
         {
             ServiceContainer.Register<MessageBus> ();
             ServiceContainer.Register<UpgradeManger> ();
-
+            ServiceContainer.Register<AuthManager> ();
             ServiceContainer.Register<ActiveTimeEntryManager> ();
             ServiceContainer.Register<DataCache> ();
             ServiceContainer.Register<ForeignRelationManager> ();
@@ -31,17 +30,8 @@ namespace Toggl.Phoebe
             ServiceContainer.Register<ITogglClient> (() => new TogglRestClient (Build.ApiUrl));
             ServiceContainer.Register<IReportsClient> (() => new ReportsRestClient (Build.ReportsApiUrl));
 
-            // Asynchronous Initialization Pattern
-            // as described at http://blog.stephencleary.com/2013/01/async-oop-2-constructors.html
-            var authManagerServ = new AuthManager ();
-            ServiceContainer.Register<AuthManager> (authManagerServ);
-
             RegisterJsonConverters ();
-
             ServiceContainer.Register<LoggerUserManager> ();
-
-            // initialise async services.
-            await authManagerServ.Initialization;
         }
 
         private static void RegisterJsonConverters ()

--- a/Ross/AppDelegate.cs
+++ b/Ross/AppDelegate.cs
@@ -34,7 +34,7 @@ namespace Toggl.Ross
             systemVersion = Convert.ToInt32 ( versionString.Split ( new [] {"."}, StringSplitOptions.None)[0]);
 
             // wait for component initialisation.
-            RegisterComponentsAsync ();
+            RegisterComponents ();
 
             Toggl.Ross.Theme.Style.Initialize ();
 
@@ -97,10 +97,13 @@ namespace Toggl.Ross
             }
         }
 
-        private async void RegisterComponentsAsync ()
+        private void RegisterComponents ()
         {
             // Register platform info first.
             ServiceContainer.Register<IPlatformInfo> (this);
+
+            // Register Phoebe services
+            Services.Register ();
 
             // Override default implementation
             ServiceContainer.Register<ITimeProvider> (() => new NSTimeProvider ());
@@ -133,9 +136,6 @@ namespace Toggl.Ross
             ServiceContainer.Register<NetworkIndicatorManager> ();
             ServiceContainer.Register<TagChipCache> ();
             ServiceContainer.Register<OAuthManager> ();
-
-            // Register Phoebe services async
-            await Services.RegisterAsync ();
         }
 
         public static TogglWindow TogglWindow

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -29,17 +29,14 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="Bugsnag">
-      <HintPath>..\packages\Toggl.Bugsnag.1.0.1\lib\net45\Bugsnag.dll</HintPath>
-    </Reference>
-    <Reference Include="Moq">
-      <HintPath>..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
-    </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="Moq">
+      <HintPath>..\packages\Moq.4.2.1507.0118\lib\net40\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="Moq" version="4.2.1507.0118" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The bug was introduced when a new version of sqlite was used. The new version converts dates to from string format to ticks format (readable to long number) by default. This conversion fails for the min value case:

<img width="479" alt="screen shot 2015-08-11 at 21 50 39" src="https://cloud.githubusercontent.com/assets/1842773/9272959/ae5b25c0-4287-11e5-8350-2f506ac970b3.png">

Min date in sqlite: 01/01/0001 0:00:00 (the new version uses 0 but for an unknown reason doesn't replace the string format) 
Min value date in C#: 01/01/0001 0:00:00
Difference: 00:00:00.0000001

There is 1 tick of difference between DateTime.MinValue and the old string format read by the new version of sqlite. This difference makes this comparison to fail:
https://github.com/toggl/mobile/blob/master/Phoebe/Data/Models/TimeEntryModel.cs#L365

Solution: replace all direct comparisons for an extension method. 

```
public static bool IsMinValue (this DateTime dateTime)
{
   return (dateTime - DateTime.MinValue).Ticks < 10;
}
````

Besides, the old synchronous way to start services is used again.
