### PR TITLE
Disable email field autocorrection on the login screen

### DIFF
--- a/Ross/ViewControllers/LoginViewController.cs
+++ b/Ross/ViewControllers/LoginViewController.cs
@@ -44,6 +44,7 @@ namespace Toggl.Ross.ViewControllers
                 ReturnKeyType = UIReturnKeyType.Next,
                 ClearButtonMode = UITextFieldViewMode.Always,
                 ShouldReturn = HandleShouldReturn,
+                AutocorrectionType = UITextAutocorrectionType.No
             } .Apply (Style.Login.EmailField));
 
             inputsContainer.Add (middleBorder = new UIView ().Apply (Style.Login.InputsBorder));


### PR DESCRIPTION
Email autocorrection/autocapitalization leads to bad UX
The issue:
![autocompletion_login_fail](https://cloud.githubusercontent.com/assets/720966/9513858/62c6434a-4c9d-11e5-9631-363663943b57.gif)
