### PR TITLE
Bind Task prop in TimeEntryModel's MapMinorsFromModel

### DIFF
--- a/Phoebe/Data/Models/TimeEntryModel.cs
+++ b/Phoebe/Data/Models/TimeEntryModel.cs
@@ -627,6 +627,7 @@ namespace Toggl.Phoebe.Data.Models
             Project = model.Project;
             Description = model.Description;
             IsBillable = model.IsBillable;
+            Task = model.Task;
             await SaveAsync ();
         }
 


### PR DESCRIPTION
Closing https://github.com/toggl/mobile/issues/890
No effect on Android (doesn't use this method)
iOS autocompletion tested with&without project's task set.

The possible reason why this line was removed is that autocompletion doesn't offer task names in its cells:
![download](https://cloud.githubusercontent.com/assets/720966/9514343/0c1c9616-4ca2-11e5-8489-0d9df6f5cce1.jpeg)
