### PR TITLE
Add cancellation token to slow web request (ListTimeEntries)

### DIFF
--- a/Joey/Joey.csproj
+++ b/Joey/Joey.csproj
@@ -684,8 +684,8 @@
     <AndroidResource Include="Resources\drawable-hdpi\icTasksSelected.png" />
     <AndroidResource Include="Resources\drawable\TasksButtonBackground.xml" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
   <Import Project="..\packages\Xamarin.Insights.1.10.6\build\MonoAndroid10\Xamarin.Insights.targets" Condition="Exists('..\packages\Xamarin.Insights.1.10.6\build\MonoAndroid10\Xamarin.Insights.targets')" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <ItemGroup>
     <ProjectReference Include="..\Phoebe\Phoebe.Android.csproj">
       <Project>{FF67B529-C11B-4FE0-AA1B-CD77141816BB}</Project>

--- a/Mobile.sln
+++ b/Mobile.sln
@@ -51,7 +51,6 @@ Global
 		{6DDC0688-0534-466A-9134-0E331AC0E998}.Release|x86.ActiveCfg = Release|iPhoneSimulator
 		{6DDC0688-0534-466A-9134-0E331AC0E998}.Release|x86.Build.0 = Release|iPhoneSimulator
 		{6DDC0688-0534-466A-9134-0E331AC0E998}.Test|Any CPU.ActiveCfg = Debug|iPhoneSimulator
-		{6DDC0688-0534-466A-9134-0E331AC0E998}.Test|Any CPU.Build.0 = Debug|iPhoneSimulator
 		{735F910D-2550-48D1-B577-735721EFE6DF}.Ad-Hoc|iPhone.ActiveCfg = Release|Any CPU
 		{735F910D-2550-48D1-B577-735721EFE6DF}.AppStore|iPhone.ActiveCfg = Release|Any CPU
 		{735F910D-2550-48D1-B577-735721EFE6DF}.Debug|iPhone.ActiveCfg = Debug|Any CPU

--- a/Phoebe/Net/ITogglClient.cs
+++ b/Phoebe/Net/ITogglClient.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Toggl.Phoebe.Data.Json;
+using System.Threading;
 
 namespace Toggl.Phoebe.Net
 {
@@ -45,7 +46,11 @@ namespace Toggl.Phoebe.Net
 
         Task<List<ProjectUserJson>> ListProjectUsers (long projectId);
 
+        Task<List<TimeEntryJson>> ListTimeEntries (DateTime start, DateTime end, CancellationToken cancellationToken);
+
         Task<List<TimeEntryJson>> ListTimeEntries (DateTime start, DateTime end);
+
+        Task<List<TimeEntryJson>> ListTimeEntries (DateTime end, int days, CancellationToken cancellationToken);
 
         Task<List<TimeEntryJson>> ListTimeEntries (DateTime end, int days);
 

--- a/Phoebe/Phoebe.Android.csproj
+++ b/Phoebe/Phoebe.Android.csproj
@@ -75,6 +75,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="..\Contrib\Trie\Trie.projitems" Label="Shared" Condition="Exists('..\Contrib\Trie\Trie.projitems')" />
-  <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
   <Import Project="..\packages\Xamarin.Insights.1.10.6\build\MonoAndroid10\Xamarin.Insights.targets" Condition="Exists('..\packages\Xamarin.Insights.1.10.6\build\MonoAndroid10\Xamarin.Insights.targets')" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>


### PR DESCRIPTION
- Added a Cancellation token to the long request of time entries.
- Added Cancellation token feature to basic SendAsync and ListObjects method. Now cancellations could be implemented but more higher level methods.