### PR TITLE
iOS Quick Action (3D Touch): Start a TE

### DIFF
--- a/Ross/QuickActions.cs
+++ b/Ross/QuickActions.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using Toggl.Phoebe;
+using Toggl.Phoebe.Data;
+using Toggl.Phoebe.Data.Models;
+using Toggl.Phoebe.Net;
+using UIKit;
+using XPlatUtils;
+
+namespace Toggl.Ross
+{
+    public static class QuickActionsIdentifier
+    {
+        public const string QuickStart = "com.toggl.timer.qstart";
+    }
+
+    public class QuickActions : IDisposable
+    {
+        private Subscription<AuthChangedMessage> subscriptionAuthChanged;
+        private Subscription<SyncFinishedMessage> subscriptionSyncFinished;
+
+        public QuickActions ()
+        {
+            var bus = ServiceContainer.Resolve<MessageBus> ();
+
+            if (subscriptionAuthChanged == null) {
+                subscriptionAuthChanged = bus.Subscribe<AuthChangedMessage> (OnAuthChanged);
+            }
+
+            if (subscriptionSyncFinished == null) {
+                subscriptionSyncFinished = bus.Subscribe<SyncFinishedMessage> (OnSyncFinished);
+            }
+
+            checkActions ();
+        }
+
+        private void OnSyncFinished (Message msg)
+        {
+            if (shouldHandleAfterSync) {
+                HandleShortcut (scheduledShortcut);
+            }
+        }
+
+        private void OnAuthChanged (AuthChangedMessage msg)
+        {
+            checkActions ();
+        }
+
+        private void checkActions()
+        {
+            var app = UIApplication.SharedApplication;
+
+            var authManager = ServiceContainer.Resolve<AuthManager> ();
+
+            if (authManager.IsAuthenticated) {
+                if (app.ShortcutItems.Length == 0) {
+                    var qstart = new UIMutableApplicationShortcutItem (QuickActionsIdentifier.QuickStart, "Start") {
+                        LocalizedSubtitle = "Will start a new time entry",
+                        Icon = UIApplicationShortcutIcon.FromType (UIApplicationShortcutIconType.Play)
+                    };
+                    app.ShortcutItems = new UIApplicationShortcutItem[] { qstart };
+                }
+            } else {
+                app.ShortcutItems = new UIApplicationShortcutItem[] { };
+            }
+        }
+
+        private bool shouldHandleAfterSync;
+        private UIApplicationShortcutItem scheduledShortcut;
+
+        public bool HandleShortcut (UIApplicationShortcutItem shortcut, bool shouldHandleAfterSync = false)
+        {
+            this.shouldHandleAfterSync = shouldHandleAfterSync;
+            if (shortcut == null) {
+                return true;
+            }
+
+            if (shouldHandleAfterSync) {
+                scheduledShortcut = shortcut;
+                return true;
+            }
+
+            if (shortcut.Type == QuickActionsIdentifier.QuickStart) {
+                StartNewEntry ();
+                return true;
+            }
+
+            return false;
+        }
+
+        private void StartNewEntry()
+        {
+            var timeEntryManager = ServiceContainer.Resolve<ActiveTimeEntryManager> ();
+            var newEntry = (TimeEntryModel) timeEntryManager.Draft;
+            newEntry.StartAsync ();
+        }
+
+        public void Dispose()
+        {
+            var bus = ServiceContainer.Resolve<MessageBus> ();
+
+            if (subscriptionAuthChanged != null) {
+                bus.Unsubscribe (subscriptionAuthChanged);
+                subscriptionAuthChanged = null;
+            }
+
+            if (subscriptionSyncFinished != null) {
+                bus.Unsubscribe (subscriptionSyncFinished);
+                subscriptionSyncFinished = null;
+            }
+        }
+    }
+}

--- a/Ross/Ross.csproj
+++ b/Ross/Ross.csproj
@@ -320,6 +320,7 @@
     <Compile Include="Views\TableViewRefreshView.cs" />
     <Compile Include="ViewControllers\WebViewController.cs" />
     <Compile Include="Net\APNSManager.cs" />
+    <Compile Include="QuickActions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Phoebe\Phoebe.iOS.csproj">


### PR DESCRIPTION
So, I implemented Quick Actions for 6S users convenience 
1. Action start a new entry. You only have to press toggl logo harder and slide a finger to the “Start” option
2. Action won’t appear if user is logged out
3. Works with background-foreground/killed states
4. This is cool
![quickaction](https://cloud.githubusercontent.com/assets/720966/10614203/97878366-7761-11e5-95cc-ebb64b6dea7a.gif)
