### PR TITLE
Make collection load async.

### DIFF
--- a/Contrib/Bind/Bind.cs
+++ b/Contrib/Bind/Bind.cs
@@ -213,9 +213,7 @@ namespace Praeclarum.Bind
                 #if __ANDROID__
                 var lambda = Expression.Lambda (handlerType, body, parameters);
                 return lambda.Compile();
-                #endif
-
-                #if __IOS__
+                #else
                 var lambda = Expression.Lambda (body, parameters);
                 var delegateInvokeInfo = lambda.Compile ().GetMethodInfo ();
                 return delegateInvokeInfo.CreateDelegate (handlerType, null);

--- a/Joey/UI/Adapters/LogTimeEntriesAdapter.cs
+++ b/Joey/UI/Adapters/LogTimeEntriesAdapter.cs
@@ -118,28 +118,29 @@ namespace Toggl.Joey.UI.Adapters
 
         protected override void BindHolder (RecyclerView.ViewHolder holder, int position)
         {
-            if (GetItemViewType (position) == ViewTypeDateHeader) {
-                var headerHolder = (HeaderListItemHolder)holder;
-                headerHolder.Bind ((TimeEntriesCollectionView.IDateGroup) GetEntry (position));
-            } else {
-                var entryHolder = (TimeEntryListItemHolder)holder;
-                entryHolder.Bind ((TimeEntryHolder) GetEntry (position));
+            if (holder is SpinnerHolder) {
+                return;
+            }
+
+            var headerListItemHolder = holder as HeaderListItemHolder;
+            if (headerListItemHolder != null) {
+                headerListItemHolder.Bind ((TimeEntriesCollectionView.IDateGroup) GetEntry (position));
+                return;
+            }
+
+            var timeEntryListItemHolder = holder as TimeEntryListItemHolder;
+            if (timeEntryListItemHolder != null) {
+                timeEntryListItemHolder.Bind ((TimeEntryHolder) GetEntry (position));
             }
         }
 
         public override int GetItemViewType (int position)
         {
-            // TODO: investigate positio > DataView.Count
-            if (position >= DataView.Count) {
-                return ViewTypeLoaderPlaceholder;
+            var type = base.GetItemViewType (position);
+            if (type != ViewTypeLoaderPlaceholder) {
+                type = GetEntry (position) is TimeEntriesCollectionView.IDateGroup ? ViewTypeDateHeader : ViewTypeContent;
             }
-
-            var obj = GetEntry (position);
-            if (obj is TimeEntriesCollectionView.IDateGroup) {
-                return ViewTypeDateHeader;
-            }
-
-            return ViewTypeContent;
+            return type;
         }
 
         public override void OnViewDetachedFromWindow (Java.Lang.Object holder)

--- a/Joey/UI/Adapters/RecycledDataViewAdapter.cs
+++ b/Joey/UI/Adapters/RecycledDataViewAdapter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Specialized;
 using System.Linq;
+using System.Threading.Tasks;
 using Android.OS;
 using Android.Support.V7.Widget;
 using Android.Views;
@@ -71,7 +72,9 @@ namespace Toggl.Joey.UI.Adapters
 
             // Sometimes a new call to LoadMore is needed.
             if (lastLoadingPosition + LoadMoreOffset > ItemCount && dataView.HasMore && !dataView.IsLoading) {
-                dataView.LoadMore ();
+                Task.Run ( async () => {
+                    await dataView.LoadMoreAsync ();
+                });
             }
         }
 
@@ -125,7 +128,9 @@ namespace Toggl.Joey.UI.Adapters
         {
             if (position + LoadMoreOffset > ItemCount && dataView.HasMore && !dataView.IsLoading) {
                 lastLoadingPosition = position;
-                dataView.LoadMore ();
+                Task.Run ( async () => {
+                    await dataView.LoadMoreAsync ();
+                });
             }
 
             if (GetItemViewType (position) == ViewTypeLoaderPlaceholder) {

--- a/Joey/UI/Fragments/LogTimeEntriesListFragment.cs
+++ b/Joey/UI/Fragments/LogTimeEntriesListFragment.cs
@@ -73,11 +73,13 @@ namespace Toggl.Joey.UI.Fragments
             }
         }
 
-        private void EnsureAdapter ()
+        private async void EnsureAdapter ()
         {
             if (recyclerView.GetAdapter() == null) {
                 var isGrouped = ServiceContainer.Resolve<SettingsStore> ().GroupedTimeEntries;
                 collectionView = isGrouped ? (TimeEntriesCollectionView)new GroupedTimeEntriesView () : new LogTimeEntriesView ();
+                await collectionView.ReloadAsync ();
+
                 logAdapter = new LogTimeEntriesAdapter (recyclerView, collectionView);
                 recyclerView.SetAdapter (logAdapter);
                 SetupRecyclerView ();

--- a/Joey/UI/Fragments/ProjectListFragment.cs
+++ b/Joey/UI/Fragments/ProjectListFragment.cs
@@ -96,15 +96,13 @@ namespace Toggl.Joey.UI.Fragments
             base.OnViewCreated (view, savedInstanceState);
 
             viewModel = new ProjectListViewModel (TimeEntryIds);
+            await viewModel.Init ();
 
             var adapter = new ProjectListAdapter (recyclerView, viewModel.ProjectList);
             adapter.HandleProjectSelection = OnItemSelected;
             recyclerView.SetAdapter (adapter);
 
-            viewModel.OnIsLoadingChanged += OnDataLoaded;
-            viewModel.ProjectList.OnIsLoadingChanged += OnDataLoaded;
-
-            await viewModel.Init ();
+            OnDataLoaded (null, null);
         }
 
         private void OnDataLoaded (object sender, EventArgs e)

--- a/Phoebe/Data/ViewModels/ProjectListViewModel.cs
+++ b/Phoebe/Data/ViewModels/ProjectListViewModel.cs
@@ -48,6 +48,9 @@ namespace Toggl.Phoebe.Data.ViewModels
 
             await model.LoadAsync ();
 
+            projectList = new WorkspaceProjectsView ();
+            await projectList.ReloadAsync ();
+
             if (model.Workspace == null || model.Workspace.Id == Guid.Empty) {
                 model = null;
             }
@@ -64,9 +67,6 @@ namespace Toggl.Phoebe.Data.ViewModels
         public WorkspaceProjectsView ProjectList
         {
             get {
-                if (projectList == null) {
-                    projectList = new WorkspaceProjectsView ();
-                }
                 return projectList;
             }
         }

--- a/Phoebe/Data/Views/ICollectionDataView.cs
+++ b/Phoebe/Data/Views/ICollectionDataView.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Threading.Tasks;
 
 namespace Toggl.Phoebe.Data.Views
 {
@@ -12,9 +13,9 @@ namespace Toggl.Phoebe.Data.Views
 
         bool HasMore { get; }
 
-        void Reload ();
+        Task ReloadAsync ();
 
-        void LoadMore ();
+        Task LoadMoreAsync ();
 
         bool IsLoading { get; }
 

--- a/Phoebe/Data/Views/TimeEntriesCollectionView.cs
+++ b/Phoebe/Data/Views/TimeEntriesCollectionView.cs
@@ -54,8 +54,6 @@ namespace Toggl.Phoebe.Data.Views
             subscriptionDataChange = bus.Subscribe<DataChangeMessage> (OnDataChange);
             HasMore = true;
 
-            Reload ();
-
             cts = new CancellationTokenSource ();
             cancellationToken = cts.Token;
         }
@@ -373,7 +371,7 @@ namespace Toggl.Phoebe.Data.Views
             }
         }
 
-        public void Reload ()
+        public async Task ReloadAsync ()
         {
             if (IsLoading) {
                 return;
@@ -394,16 +392,16 @@ namespace Toggl.Phoebe.Data.Views
                     subscriptionSyncFinished = bus.Subscribe<SyncFinishedMessage> (OnSyncFinished);
                 }
             } else {
-                Load (true);
+                await Load (true);
             }
         }
 
-        public void LoadMore ()
+        public async Task LoadMoreAsync ()
         {
-            Load (false);
+            await Load (false);
         }
 
-        private async void Load (bool initialLoad)
+        private async Task Load (bool initialLoad)
         {
             if (IsLoading || !HasMore) {
                 return;

--- a/Phoebe/Data/Views/TimeEntriesCollectionView.cs
+++ b/Phoebe/Data/Views/TimeEntriesCollectionView.cs
@@ -364,17 +364,17 @@ namespace Toggl.Phoebe.Data.Views
             DateGroups.Clear ();
             HasMore = true;
 
-            await Load (true);
+            await LoadAsync (true);
         }
 
         public async Task LoadMoreAsync ()
         {
             if (isInitialised) {
-                await Load (false);
+                await LoadAsync (false);
             }
         }
 
-        private async Task Load (bool initialLoad)
+        private async Task LoadAsync (bool initialLoad)
         {
             if (IsLoading || !HasMore) {
                 return;

--- a/Phoebe/Data/Views/WorkspaceProjectsView.cs
+++ b/Phoebe/Data/Views/WorkspaceProjectsView.cs
@@ -33,7 +33,6 @@ namespace Toggl.Phoebe.Data.Views
             userData = ServiceContainer.Resolve<AuthManager> ().User;
             var bus = ServiceContainer.Resolve<MessageBus> ();
             subscriptionDataChange = bus.Subscribe<DataChangeMessage> (OnDataChange);
-            Reload ();
         }
 
         public Project UnfoldedTaskProject
@@ -345,7 +344,7 @@ namespace Toggl.Phoebe.Data.Views
             }
         }
 
-        public async void Reload ()
+        public async Task ReloadAsync ()
         {
             if (IsLoading) {
                 return;
@@ -612,7 +611,7 @@ namespace Toggl.Phoebe.Data.Views
                        ));
         }
 
-        public void LoadMore () {}
+        public Task LoadMoreAsync () { return null; }
 
         private void UpdateCollection ()
         {


### PR DESCRIPTION
Finally the ICollectionDataView have async methods like ReloadAsync and LoadMoreAsync. Now everything makes more sense (the Init on ViewModels) etc. Still there is a bad use of it in some fragments but this code will help for further PRs.

Besides, the code to wait for the sync manager was removed from TimeEntriesCollectionView in order to do the load of items a bit faster.
