### PR TITLE
Update to multiples ViewModels.

### DIFF
--- a/Joey/Joey.csproj
+++ b/Joey/Joey.csproj
@@ -180,8 +180,8 @@
     <Compile Include="UI\Views\AddProjectFab.cs" />
     <Compile Include="UI\Views\TogglAppBar.cs" />
     <Compile Include="UI\Fragments\CreateClientDialogFragment.cs" />
-    <Compile Include="UI\Fragments\ClientListFragment.cs" />
     <Compile Include="UI\Adapters\ClientsAdapter.cs" />
+    <Compile Include="UI\Fragments\ClientListDialogFragment.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />

--- a/Joey/UI/Activities/NewProjectActivity.cs
+++ b/Joey/UI/Activities/NewProjectActivity.cs
@@ -1,9 +1,7 @@
-﻿using System.Collections.Generic;
-using Android.App;
+﻿using Android.App;
 using Android.Content.PM;
 using Android.OS;
 using Toggl.Joey.UI.Fragments;
-using Toggl.Phoebe.Data.DataObjects;
 using Activity = Android.Support.V7.App.AppCompatActivity;
 using Fragment = Android.Support.V4.App.Fragment;
 
@@ -21,10 +19,8 @@ namespace Toggl.Joey.UI.Activities
             base.OnCreateActivity (state);
             SetContentView (Resource.Layout.NewProjectActivity);
 
-            var timeEntryList = BaseActivity.GetDataFromIntent <List<TimeEntryData>> (Intent, ExtraTimeEntryDataListId);
-
             SupportFragmentManager.BeginTransaction ()
-            .Add (Resource.Id.NewProjectActivityLayout, new NewProjectFragment (timeEntryList))
+            .Add (Resource.Id.NewProjectActivityLayout, NewProjectFragment.NewInstance ())
             .Commit ();
         }
     }

--- a/Joey/UI/Adapters/ClientsAdapter.cs
+++ b/Joey/UI/Adapters/ClientsAdapter.cs
@@ -17,6 +17,8 @@ namespace Toggl.Joey.UI.Adapters
 
         public Action<object> HandleClientSelection { get; set; }
 
+        public int SelectedClientIndex { get; set; }
+
         public ClientsAdapter (IDataView<ClientData> view) : base (view)
         {
         }
@@ -92,13 +94,6 @@ namespace Toggl.Joey.UI.Adapters
 
             protected override void ResetTrackedObservables ()
             {
-                Tracker.MarkAllStale ();
-
-                if (DataSource != null) {
-                    Tracker.Add (DataSource, HandleClientPropertyChanged);
-                }
-
-                Tracker.ClearStale ();
             }
 
             protected override void Rebind ()
@@ -108,20 +103,11 @@ namespace Toggl.Joey.UI.Adapters
                     return;
                 }
 
-                ResetTrackedObservables ();
-
                 if (DataSource == null) {
                     return;
                 }
 
                 ClientTextView.Text = DataSource.Name;
-            }
-
-            private void HandleClientPropertyChanged (string prop)
-            {
-                if (prop == ClientModel.PropertyName) {
-                    Rebind ();
-                }
             }
         }
         #endregion

--- a/Joey/UI/Fragments/NewProjectFragment.cs
+++ b/Joey/UI/Fragments/NewProjectFragment.cs
@@ -18,7 +18,7 @@ using Toolbar = Android.Support.V7.Widget.Toolbar;
 
 namespace Toggl.Joey.UI.Fragments
 {
-    public class NewProjectFragment : Fragment
+    public class NewProjectFragment : Fragment, IOnClientSelectedListener
     {
         public static readonly int ClientSelectedRequestCode = 1;
 
@@ -72,6 +72,9 @@ namespace Toggl.Joey.UI.Fragments
             selectClientBit = view.FindViewById<TogglField> (Resource.Id.SelectClientNameBit)
                               .DestroyAssistView().SetName (Resource.String.NewProjectSelectClientFieldName)
                               .SimulateButton();
+
+            selectClientBit.TextField.Click += SelectClientBitClickedHandler;
+            selectClientBit.Click += SelectClientBitClickedHandler;
 
             colorPicker = view.FindViewById<ColorPickerRecyclerView> (Resource.Id.NewProjectColorPickerRecyclerView);
             HasOptionsMenu = true;
@@ -136,15 +139,19 @@ namespace Toggl.Joey.UI.Fragments
 
         private void SelectClientBitClickedHandler (object sender, EventArgs e)
         {
-            //new ClientListDialogFragment (viewModel.Model.Data.WorkspaceId, viewModel.Model)
-
-            //.Show (FragmentManager, "clients_dialog");
-            var dialog = new ClientListDialogFragment (viewModel.Model.Data.WorkspaceId, viewModel.Model);
-            dialog.Dialog.DismissEvent += (object sender, EventArgs e) => {
-
-            };
-            dialog.Show ();
+            ClientListDialogFragment.NewInstance (timeEntryList[0].WorkspaceId)
+            .SetClientSelectListener (this)
+            .Show (FragmentManager, "clients_dialog");
         }
+
+        #region IOnClientSelectedListener implementation
+
+        public void OnClientSelected (ClientData data)
+        {
+            viewModel.SetClient (data);
+        }
+
+        #endregion
 
         public override void OnCreateOptionsMenu (IMenu menu, MenuInflater inflater)
         {

--- a/Joey/UI/Fragments/NewProjectFragment.cs
+++ b/Joey/UI/Fragments/NewProjectFragment.cs
@@ -84,6 +84,7 @@ namespace Toggl.Joey.UI.Fragments
 
             viewModel = new NewProjectViewModel (TimeEntryList);
             binding = Binding.Create (() =>
+                                      selectClientBit.TextField.Text == viewModel.ClientName &&
                                       projectBit.TextField.Text == viewModel.ProjectName &&
                                       colorPicker.Adapter.SelectedColor == viewModel.ProjectColor);
 
@@ -100,6 +101,8 @@ namespace Toggl.Joey.UI.Fragments
         public override void OnStart ()
         {
             base.OnStart ();
+
+            // show keyboard
             var inputService = (InputMethodManager)Activity.GetSystemService (Context.InputMethodService);
             projectBit.TextField.PostDelayed (delegate {
                 inputService.ShowSoftInput (projectBit.TextField, ShowFlags.Implicit);
@@ -133,7 +136,14 @@ namespace Toggl.Joey.UI.Fragments
 
         private void SelectClientBitClickedHandler (object sender, EventArgs e)
         {
-            new ClientListFragment (viewModel.Model.Data.WorkspaceId, viewModel.Model).Show (FragmentManager, "clients_dialog");
+            //new ClientListDialogFragment (viewModel.Model.Data.WorkspaceId, viewModel.Model)
+
+            //.Show (FragmentManager, "clients_dialog");
+            var dialog = new ClientListDialogFragment (viewModel.Model.Data.WorkspaceId, viewModel.Model);
+            dialog.Dialog.DismissEvent += (object sender, EventArgs e) => {
+
+            };
+            dialog.Show ();
         }
 
         public override void OnCreateOptionsMenu (IMenu menu, MenuInflater inflater)

--- a/Joey/UI/Fragments/NewProjectFragment.cs
+++ b/Joey/UI/Fragments/NewProjectFragment.cs
@@ -83,12 +83,11 @@ namespace Toggl.Joey.UI.Fragments
             base.OnViewCreated (view, savedInstanceState);
 
             viewModel = new NewProjectViewModel (TimeEntryList);
-            await viewModel.Init ();
+            binding = Binding.Create (() =>
+                                      projectBit.TextField.Text == viewModel.ProjectName &&
+                                      colorPicker.Adapter.SelectedColor == viewModel.ProjectColor);
 
-            binding = Binding.Create (() => projectBit.TextField.Text == viewModel.ProjectName);
-            colorPicker.SelectedColorChanged += (sender, e) => {
-                viewModel.ProjectColor = e;
-            };
+            await viewModel.Init ();
         }
 
         public override void OnDestroyView ()

--- a/Joey/UI/Views/ColorPickerRecyclerView.cs
+++ b/Joey/UI/Views/ColorPickerRecyclerView.cs
@@ -38,18 +38,12 @@ namespace Toggl.Joey.UI.Views
         public ColorPickerAdapter Adapter { get; private set; }
         public RecyclerView.LayoutManager LayoutManager { get; private set; }
 
-        public event EventHandler<int> SelectedColorChanged
-        {
-            add { Adapter.SelectedColorChanged += value; }
-            remove { Adapter.SelectedColorChanged -= value; }
-        }
-
         public static int ColumnsCount = 5;
         public static int RowsCount = 5;
 
         private void Initialize ()
         {
-            LayoutInflater inflater = (LayoutInflater)Context.GetSystemService (Context.LayoutInflaterService);
+            var inflater = (LayoutInflater)Context.GetSystemService (Context.LayoutInflaterService);
             inflater.Inflate (Resource.Layout.ColorPicker, this);
 
             Recycler = FindViewById<RecyclerView> (Resource.Id.ColorPickerRecyclerView);
@@ -63,9 +57,9 @@ namespace Toggl.Joey.UI.Views
 
         public class ColorPickerAdapter : RecyclerView.Adapter
         {
-
-            public int SelectedColor { get; private set; }
+            // SelectedColorChanged is needed for binding!
             public event EventHandler<int> SelectedColorChanged;
+            public int SelectedColor { get; private set; }
 
             public ColorPickerAdapter()
             {
@@ -113,7 +107,7 @@ namespace Toggl.Joey.UI.Views
 
                 public ColorPickerViewHolder (View v, Action<int> listener) : base (v)
                 {
-                    v.Click += (sender, e) => listener (base.Position);
+                    v.Click += (sender, e) => listener (AdapterPosition);
                     Tick = v.FindViewById<ImageView> (Resource.Id.ColorPickerViewTick);
                     Tick.BringToFront();
                     Button = v.FindViewById<View> (Resource.Id.ColorPickerViewButton);

--- a/Joey/UI/Views/ColorPickerRecyclerView.cs
+++ b/Joey/UI/Views/ColorPickerRecyclerView.cs
@@ -58,7 +58,7 @@ namespace Toggl.Joey.UI.Views
         public class ColorPickerAdapter : RecyclerView.Adapter
         {
             // SelectedColorChanged is needed for binding!
-            public event EventHandler<int> SelectedColorChanged;
+            public event EventHandler SelectedColorChanged;
             public int SelectedColor { get; private set; }
 
             public ColorPickerAdapter()
@@ -96,7 +96,7 @@ namespace Toggl.Joey.UI.Views
                 SelectedColor = position;
                 NotifyDataSetChanged ();
                 if (SelectedColorChanged != null) {
-                    SelectedColorChanged (this, SelectedColor);
+                    SelectedColorChanged (this, EventArgs.Empty);
                 }
             }
 

--- a/Joey/UI/Views/TogglField.cs
+++ b/Joey/UI/Views/TogglField.cs
@@ -8,7 +8,8 @@ namespace Toggl.Joey.UI.Views
 {
     public class TogglField : RelativeLayout
     {
-        public EditText TextField;
+        public EditText TextField { get; private set; }
+
         private TextView titleText;
         private TextView assistView;
         private ImageView arrow;

--- a/Joey/UI/Views/TogglField.cs
+++ b/Joey/UI/Views/TogglField.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using Android.Content;
-using Android.Text;
+﻿using Android.Content;
 using Android.Util;
 using Android.Views;
 using Android.Views.InputMethods;

--- a/Phoebe/Data/ActiveTimeEntryManager.cs
+++ b/Phoebe/Data/ActiveTimeEntryManager.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using PropertyChanged;
 using Toggl.Phoebe.Data.DataObjects;
 using Toggl.Phoebe.Data.Models;
 using Toggl.Phoebe.Net;
@@ -11,6 +12,7 @@ using XPlatUtils;
 
 namespace Toggl.Phoebe.Data
 {
+    [DoNotNotify]
     public sealed class ActiveTimeEntryManager : INotifyPropertyChanged, IDisposable
     {
         private static string GetPropertyName<T> (Expression<Func<ActiveTimeEntryManager, T>> expr)

--- a/Phoebe/Data/Models/Model.cs
+++ b/Phoebe/Data/Models/Model.cs
@@ -2,12 +2,14 @@
 using System.ComponentModel;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using PropertyChanged;
 using Toggl.Phoebe.Data.DataObjects;
 using Toggl.Phoebe.Logging;
 using XPlatUtils;
 
 namespace Toggl.Phoebe.Data.Models
 {
+    [DoNotNotify]
     public abstract class Model<T> : IModel
         where T : CommonData, new()
     {

--- a/Phoebe/Data/Utils/TimeEntryGroup.cs
+++ b/Phoebe/Data/Utils/TimeEntryGroup.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
+using PropertyChanged;
 using Toggl.Phoebe.Data.DataObjects;
 using Toggl.Phoebe.Data.Models;
 using XPlatUtils;
@@ -15,6 +16,7 @@ namespace Toggl.Phoebe.Data.Utils
     // The class presents a TimeEntryModel (the last time entry added) to work correclty with
     // the Views created but actually manage a list of TimeEntryData
     /// </summary>
+    [DoNotNotify]
     public class TimeEntryGroup : ITimeEntryModel
     {
         private readonly List<TimeEntryData> dataObjects = new List<TimeEntryData> ();

--- a/Phoebe/Data/ViewModels/ClientListViewModel.cs
+++ b/Phoebe/Data/ViewModels/ClientListViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Threading.Tasks;
 using Toggl.Phoebe.Analytics;
 using Toggl.Phoebe.Data.DataObjects;
@@ -10,16 +9,13 @@ using XPlatUtils;
 
 namespace Toggl.Phoebe.Data.ViewModels
 {
-    public class ClientListViewModel : IViewModel<ProjectModel>
+    public class ClientListViewModel : IVModel<ClientModel>
     {
-        private bool isLoading;
-        private WorkspaceClientsView clientList;
-        private ProjectModel model;
+        private ClientModel model;
         private Guid workspaceId;
 
-        public ClientListViewModel (Guid workspaceId, ProjectModel projectModel)
+        public ClientListViewModel (Guid workspaceId)
         {
-            this.model = projectModel;
             this.workspaceId = workspaceId;
             ServiceContainer.Resolve<ITracker> ().CurrentScreen = "Select Client";
         }
@@ -28,84 +24,34 @@ namespace Toggl.Phoebe.Data.ViewModels
         {
             IsLoading = true;
 
-            clientList = new WorkspaceClientsView (workspaceId);
-
-            if (model.Workspace == null || model.Workspace.Id == Guid.Empty) {
-                model = null;
-            }
+            ClientListDataView = new WorkspaceClientsView (workspaceId);
 
             IsLoading = false;
         }
 
         public void Dispose ()
         {
-            model.PropertyChanged -= OnModelPropertyChanged;
-            clientList.Dispose ();
             model = null;
         }
 
+        public int SelectedClientIndex { get; set; }
 
-        public Guid WorkspaceId
-        {
-            get {
-                return workspaceId;
-            }
-        }
+        public bool IsLoading { get; set; }
 
-        public IDataView<ClientData> ClientListDataView
-        {
-            get {
-                return clientList;
-            }
-        }
+        public string ClientName { get; set; }
 
-        public event EventHandler OnModelChanged;
+        public IDataView<ClientData> ClientListDataView { get; set;}
 
-        public ProjectModel Model
-        {
-            get {
-                return model;
-            }
-
-            private set {
-
-                model = value;
-
-                if (OnModelChanged != null) {
-                    OnModelChanged (this, EventArgs.Empty);
-                }
-            }
-        }
 
         public void SaveClient (ClientModel client)
         {
-            model.Client = client;
+
         }
 
-        public event EventHandler OnIsLoadingChanged;
-
-        public bool IsLoading
+        public async Task CreateNewClient ()
         {
-            get {
-                return isLoading;
-            }
-            private set {
-                isLoading = value;
 
-                if (OnIsLoadingChanged != null) {
-                    OnIsLoadingChanged (this, EventArgs.Empty);
-                }
-            }
         }
 
-        private void OnModelPropertyChanged (object sender, PropertyChangedEventArgs args)
-        {
-            if (args.PropertyName == TimeEntryModel.PropertyWorkspace) {
-                if (clientList != null) {
-                    clientList.WorkspaceId = model.Workspace.Id;
-                    workspaceId = model.Workspace.Id;
-                }
-            }
-        }
     }
 }

--- a/Phoebe/Data/ViewModels/ClientListViewModel.cs
+++ b/Phoebe/Data/ViewModels/ClientListViewModel.cs
@@ -34,24 +34,8 @@ namespace Toggl.Phoebe.Data.ViewModels
             model = null;
         }
 
-        public int SelectedClientIndex { get; set; }
-
         public bool IsLoading { get; set; }
 
-        public string ClientName { get; set; }
-
         public IDataView<ClientData> ClientListDataView { get; set;}
-
-
-        public void SaveClient (ClientModel client)
-        {
-
-        }
-
-        public async Task CreateNewClient ()
-        {
-
-        }
-
     }
 }

--- a/Phoebe/Data/ViewModels/CreateClientViewModel.cs
+++ b/Phoebe/Data/ViewModels/CreateClientViewModel.cs
@@ -44,8 +44,7 @@ namespace Toggl.Phoebe.Data.ViewModels
 
         public string ClientName { get; set; }
 
-
-        public async Task SaveNewClient ()
+        public async Task<ClientData> SaveNewClient ()
         {
             var store = ServiceContainer.Resolve<IDataStore>();
             var existing = await store.Table<ClientData>()
@@ -59,11 +58,7 @@ namespace Toggl.Phoebe.Data.ViewModels
             }
 
             await model.SaveAsync ();
-        }
 
-
-        public ClientData GetClientData ()
-        {
             return model.Data;
         }
     }

--- a/Phoebe/Data/ViewModels/NewProjectViewModel.cs
+++ b/Phoebe/Data/ViewModels/NewProjectViewModel.cs
@@ -45,31 +45,23 @@ namespace Toggl.Phoebe.Data.ViewModels
         {
             IsLoading = true;
 
-            try {
-                var user = ServiceContainer.Resolve<AuthManager> ().User;
-                if (user == null) {
-                    model = null;
-                    return;
-                }
+            workspaceId = timeEntryList[0].WorkspaceId;
+            workspaceModel = new WorkspaceModel (workspaceId);
+            await workspaceModel.LoadAsync ();
 
-                workspaceId = timeEntryList[0].WorkspaceId;
-                workspaceModel = new WorkspaceModel (workspaceId);
-                await workspaceModel.LoadAsync ();
-
-                model = new ProjectModel {
-                    Workspace = workspaceModel,
-                    IsActive = true,
-                    IsPrivate = true
-                };
-
-                if (model.Workspace == null || model.Workspace.Id == Guid.Empty) {
-                    model = null;
-                }
-            } catch (Exception ex) {
-                model = null;
-            }
+            model = new ProjectModel {
+                Workspace = workspaceModel,
+                IsActive = true,
+                IsPrivate = true
+            };
 
             IsLoading = false;
+        }
+
+        public void SetClient (ClientData clientData)
+        {
+            model.Client = new ClientModel (clientData);
+            ClientName = clientData.Name;
         }
 
         public async Task<SaveProjectResult> SaveProjectModel ()

--- a/Phoebe/Data/ViewModels/NewProjectViewModel.cs
+++ b/Phoebe/Data/ViewModels/NewProjectViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using PropertyChanged;
 using Toggl.Phoebe.Analytics;
 using Toggl.Phoebe.Data.DataObjects;
 using Toggl.Phoebe.Data.Models;
@@ -10,9 +11,9 @@ using XPlatUtils;
 
 namespace Toggl.Phoebe.Data.ViewModels
 {
-    public class NewProjectViewModel : IViewModel<ProjectModel>
+    [ImplementPropertyChanged]
+    public class NewProjectViewModel : IVModel<ProjectModel>
     {
-        private bool isLoading;
         private ProjectModel model;
         private WorkspaceModel workspaceModel;
         private Guid workspaceId;
@@ -30,35 +31,15 @@ namespace Toggl.Phoebe.Data.ViewModels
             model = null;
         }
 
-        public ProjectModel Model
-        {
-            get {
-                return model;
-            }
-        }
+        public bool IsLoading { get; set; }
 
-        public event EventHandler OnIsLoadingChanged;
+        public bool IsSaving { get; set; }
 
-        public event EventHandler OnModelChanged;
+        public string ProjectName { get; set; }
 
-        public bool IsLoading
-        {
-            get {
-                return isLoading;
-            }
-            private set {
+        public int ProjectColor { get; set; }
 
-                if (isLoading  == value) {
-                    return;
-                }
-
-                isLoading = value;
-
-                if (OnIsLoadingChanged != null) {
-                    OnIsLoadingChanged (this, EventArgs.Empty);
-                }
-            }
-        }
+        public Guid ClientId { get; set; }
 
         public async Task Init ()
         {
@@ -86,21 +67,31 @@ namespace Toggl.Phoebe.Data.ViewModels
                 }
             } catch (Exception ex) {
                 model = null;
-            } finally {
-                model.PropertyChanged += OnModelChange;
-                IsLoading = false;
             }
+
+            IsLoading = false;
         }
 
-        private void OnModelChange (object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        public async Task<SaveProjectResult> SaveProjectModel ()
         {
-            if (OnModelChanged != null) {
-                OnModelChanged (this, EventArgs.Empty);
-            }
-        }
+            IsSaving = true;
 
-        public async Task SaveProjectModel ()
-        {
+            // Project name is empty
+            if (string.IsNullOrEmpty (ProjectName)) {
+                IsSaving = false;
+                return SaveProjectResult.NameIsEmpty;
+            }
+
+            // Project name is used
+            var exists = await ExistProjectWithName (ProjectName);
+            if (exists) {
+                IsSaving = false;
+                return SaveProjectResult.NameExists;
+            }
+
+            model.Name = ProjectName;
+            model.Color = ProjectColor;
+
             // Save new project.
             await model.SaveAsync();
 
@@ -120,15 +111,25 @@ namespace Toggl.Phoebe.Data.ViewModels
             timeEntryGroup.Project = model;
             timeEntryGroup.Workspace = workspaceModel;
             await timeEntryGroup.SaveAsync ();
+
+            IsSaving = false;
+
+            return SaveProjectResult.SaveOk;
         }
 
-        public async Task<bool> ExistProjectWithName (string projectName)
+        private async Task<bool> ExistProjectWithName (string projectName)
         {
             var dataStore = ServiceContainer.Resolve<IDataStore> ();
             Guid clientId = (model.Client == null) ? Guid.Empty : model.Client.Id;
             var existWithName = await dataStore.Table<ProjectData>().ExistWithNameAsync (projectName, clientId);
 
             return existWithName;
+        }
+
+        public enum SaveProjectResult {
+            SaveOk = 0,
+            NameIsEmpty = 1,
+            NameExists = 2
         }
     }
 }

--- a/Phoebe/Data/ViewModels/NewProjectViewModel.cs
+++ b/Phoebe/Data/ViewModels/NewProjectViewModel.cs
@@ -39,7 +39,7 @@ namespace Toggl.Phoebe.Data.ViewModels
 
         public int ProjectColor { get; set; }
 
-        public Guid ClientId { get; set; }
+        public string ClientName { get; set; }
 
         public async Task Init ()
         {

--- a/Phoebe/ObservableObject.cs
+++ b/Phoebe/ObservableObject.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.ComponentModel;
+using PropertyChanged;
 
 #if false
 #define NotifyPropertyChanging
 #endif
 namespace Toggl.Phoebe
 {
+    [DoNotNotify]
     public class ObservableObject :
         #if NotifyPropertyChanging
         INotifyPropertyChanging,

--- a/Phoebe/Phoebe.Desktop.csproj
+++ b/Phoebe/Phoebe.Desktop.csproj
@@ -38,6 +38,9 @@
     <Reference Include="System.Threading.Tasks.Dataflow">
       <HintPath>..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
     </Reference>
+    <Reference Include="PropertyChanged">
+      <HintPath>..\packages\PropertyChanged.Fody.1.50.3\Lib\portable-net4+sl4+wp8+win8+wpa81+MonoAndroid16+MonoTouch40\PropertyChanged.dll</HintPath>
+    </Reference>    
     <Reference Include="System.Net.Http" />
     <Reference Include="Microsoft.Practices.ServiceLocation">
       <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
@@ -74,7 +77,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="FodyWeavers.xml" />
   </ItemGroup>
   <Import Project="..\Contrib\Trie\Trie.projitems" Label="Shared" Condition="Exists('..\Contrib\Trie\Trie.projitems')" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
 </Project>

--- a/Phoebe/Phoebe.iOS.csproj
+++ b/Phoebe/Phoebe.iOS.csproj
@@ -61,7 +61,9 @@
     </Reference>
     <Reference Include="GalaSoft.MvvmLight.Platform">
       <HintPath>..\packages\MvvmLightLibs.5.2.0.0\lib\monoandroid1\GalaSoft.MvvmLight.Platform.dll</HintPath>
-    </Reference>    
+    <Reference Include="PropertyChanged">
+      <HintPath>..\packages\PropertyChanged.Fody.1.50.3\Lib\portable-net4+sl4+wp8+win8+wpa81+MonoAndroid16+MonoTouch40\PropertyChanged.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Contrib\sqlite-net\src\SQLite.cs">

--- a/Phoebe/Phoebe.iOS.csproj
+++ b/Phoebe/Phoebe.iOS.csproj
@@ -61,6 +61,7 @@
     </Reference>
     <Reference Include="GalaSoft.MvvmLight.Platform">
       <HintPath>..\packages\MvvmLightLibs.5.2.0.0\lib\monoandroid1\GalaSoft.MvvmLight.Platform.dll</HintPath>
+    </Reference>    
     <Reference Include="PropertyChanged">
       <HintPath>..\packages\PropertyChanged.Fody.1.50.3\Lib\portable-net4+sl4+wp8+win8+wpa81+MonoAndroid16+MonoTouch40\PropertyChanged.dll</HintPath>
     </Reference>

--- a/Phoebe/packages.config
+++ b/Phoebe/packages.config
@@ -12,6 +12,8 @@
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="MonoAndroid403" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="xamarinios10" />
   <package id="PropertyChanged.Fody" version="1.50.3" targetFramework="MonoAndroid403" developmentDependency="true" />
+  <package id="PropertyChanged.Fody" version="1.50.3" targetFramework="net45" developmentDependency="true" />
+  <package id="PropertyChanged.Fody" version="1.50.3" targetFramework="xamarinios10" developmentDependency="true" />
   <package id="Xamarin.Insights" version="1.11.1" targetFramework="net40" />
   <package id="Xamarin.Insights" version="1.11.1" targetFramework="MonoAndroid403" />
   <package id="Xamarin.Insights" version="1.11.1" targetFramework="xamarinios10" />


### PR DESCRIPTION
The follow VM were updated:
- NewProjectViewModel
- ClientListViewModel
- CreateClientViewModel

Now the structure is more adaptive to change. The dialogs only return a ClientData object and there are not "Models" objects except inside the ViewModels. 
- CreateClientDialog: Create a client and returns a ClientData (doesn't modify a Project)
- ClientListDialog: Only returns a ClientData.
- All operations are made in NewProjectViewModel ( or the corresponding fragment).

To pass data between dialogs, a listener-interface pattern is used, more like Android style.
