### PR TITLE
Account for obm field not present.

### DIFF
--- a/Joey/UI/Fragments/LogTimeEntriesListFragment.cs
+++ b/Joey/UI/Fragments/LogTimeEntriesListFragment.cs
@@ -145,7 +145,7 @@ namespace Toggl.Joey.UI.Fragments
 
         private void ShowEmptyState ()
         {
-            if (!OBMExperimentManager.InExperimentGroups (OBMExperimentManager.HomeEmptyState)) { //Empty state is experimental.
+            if (!OBMExperimentManager.IncludedInExperiment (OBMExperimentManager.HomeEmptyState)) { //Empty state is experimental.
                 return;
             }
 

--- a/Phoebe/Data/Json/Converters/UserJsonConverter.cs
+++ b/Phoebe/Data/Json/Converters/UserJsonConverter.cs
@@ -52,8 +52,8 @@ namespace Toggl.Phoebe.Data.Json.Converters
             data.TrackingMode = json.StoreStartAndStopTime ? TrackingMode.StartNew : TrackingMode.Continue;
             data.DefaultWorkspaceId = defaultWorkspaceId;
             data.DurationFormat = json.DurationFormat;
-            data.ExperimentIncluded = json.OBM.Included;
-            data.ExperimentNumber = json.OBM.Number;
+            data.ExperimentIncluded = json.OBM != null && json.OBM.Included;
+            data.ExperimentNumber = json.OBM == null ? 0 : json.OBM.Number;
 
             ImportCommonJson (data, json);
         }

--- a/Phoebe/OBMExperimentManager.cs
+++ b/Phoebe/OBMExperimentManager.cs
@@ -21,7 +21,7 @@ namespace Toggl.Phoebe
             }
         }
 
-        public static bool InludedInExperiment (int experimentNumber)
+        public static bool IncludedInExperiment (int experimentNumber)
         {
             var userData = ServiceContainer.Resolve<AuthManager> ().User;
             return userData.ExperimentIncluded && userData.ExperimentNumber == experimentNumber;


### PR DESCRIPTION
obm has an omit flag in backend, so we should account for that.
that also fixes failing tests.