### PR TITLE
Fix issue #1057: Confusing buttons in Client Select Dialog

### DIFF
--- a/Joey/UI/Fragments/ClientListDialogFragment.cs
+++ b/Joey/UI/Fragments/ClientListDialogFragment.cs
@@ -86,8 +86,7 @@ namespace Toggl.Joey.UI.Fragments
             var dia = new AlertDialog.Builder (Activity)
             .SetTitle (Resource.String.SelectClientTitle)
             .SetAdapter (clientsAdapter, (IDialogInterfaceOnClickListener)null)
-            .SetPositiveButton (Resource.String.CreateClientDialogOk, delegate {})
-            .SetNeutralButton (Resource.String.ClientsNewClient, OnCreateButtonClicked)
+            .SetPositiveButton (Resource.String.ClientsNewClient, OnCreateButtonClicked)
             .Create ();
 
             listView = dia.ListView;

--- a/Joey/UI/Fragments/NewProjectFragment.cs
+++ b/Joey/UI/Fragments/NewProjectFragment.cs
@@ -143,11 +143,18 @@ namespace Toggl.Joey.UI.Fragments
             }
         }
 
-        private void SelectClientBitClickedHandler (object sender, EventArgs e)
+        private async void SelectClientBitClickedHandler (object sender, EventArgs e)
         {
-            ClientListDialogFragment.NewInstance (WorkspaceId)
-            .SetClientSelectListener (this)
-            .Show (FragmentManager, "clients_dialog");
+            if (await ClientListViewModel.ContainsClients (WorkspaceId)) {
+                ClientListDialogFragment.NewInstance (WorkspaceId)
+                    .SetClientSelectListener (this)
+                    .Show (FragmentManager, "clients_dialog");
+            }
+            else {
+                CreateClientDialogFragment.NewInstance (WorkspaceId)
+                    .SetOnClientSelectedListener (this)
+                    .Show (FragmentManager, "new_client_dialog");
+            }
         }
 
         #region IOnClientSelectedListener implementation

--- a/Phoebe/Data/ViewModels/ClientListViewModel.cs
+++ b/Phoebe/Data/ViewModels/ClientListViewModel.cs
@@ -26,6 +26,11 @@ namespace Toggl.Phoebe.Data.ViewModels
                           .Where (r => r.DeletedAt == null && r.WorkspaceId == workspaceId)
                           .ToListAsync();
 
+            Sort (clients);
+            if (clients.Count == 0) {
+                clients.Add (new ClientData () { Name = "No client" });
+            }
+
             vm.Sort (clients);
             vm.ClientDataCollection.AddRange (clients);
             return vm;


### PR DESCRIPTION
Just sending the PR so it can be reviewed, code can still change.
This PR is doing two things:
* Eliminate button "Create" in Select Client dialog. The function of this button was actually to dismiss the dialog, but this can be done by touching outside the dialog so it's not actually needed ("New client" button remains).
* When selecting a client in the Edit Project screen, if there're no clients, the New Client dialog will be open directly instead of the Select Client dialog.