### PR TITLE
Fix TimeEntriesCollectionView tests

### DIFF
--- a/Joey/UI/Adapters/RecycledDataViewAdapter.cs
+++ b/Joey/UI/Adapters/RecycledDataViewAdapter.cs
@@ -86,7 +86,7 @@ namespace Toggl.Joey.UI.Adapters
         public override async void OnBindViewHolder (RecyclerView.ViewHolder holder, int position)
         {
             if (position + LoadMoreOffset > ItemCount && dataView.HasMore) {
-                await dataView.LoadMore (); // TODO: Check if this is blocking the start of spinner animation
+                await dataView.LoadMore ();
             }
 
             if (GetItemViewType (position) == ViewTypeLoaderPlaceholder) {

--- a/Phoebe/Data/Diff.cs
+++ b/Phoebe/Data/Diff.cs
@@ -40,7 +40,7 @@ namespace Toggl.Phoebe.Data
         public bool IsMove
         {
             get { return Move != DiffMove.None; }
-        }       
+        }
 
         public DiffSection (DiffType type, int oldIndex, T oldItem, int newIndex, T newItem)
         {
@@ -93,25 +93,26 @@ namespace Toggl.Phoebe.Data
             var diffs = Calculate (listA, listB, startA, endA, startB, endB);
 
             var diffsWithReplace = diffs.Select (x => {
-                    if (x.Type == DiffType.Copy && x.OldItem.Compare (x.NewItem) != DiffComparison.Same)
-                        x.Type = DiffType.Replace;
-                    return x;
-                });
+                if (x.Type == DiffType.Copy && x.OldItem.Compare (x.NewItem) != DiffComparison.Same) {
+                    x.Type = DiffType.Replace;
+                }
+                return x;
+            });
 
             var diffsDic = diffsWithReplace
-                .GroupBy (diff => diff.Type)
-                .ToDictionary (gr => gr.Key, gr => gr.ToList ());
+                           .GroupBy (diff => diff.Type)
+                           .ToDictionary (gr => gr.Key, gr => gr.ToList ());
 
             // Calculate Move diffs
             if (diffsDic.ContainsKey (DiffType.Add) && diffsDic.ContainsKey (DiffType.Remove)) {
                 foreach (var addDiff in diffsDic[DiffType.Add]) {
                     var rmDiff = diffsDic [DiffType.Remove].FirstOrDefault (x =>
-                        listA [x.OldIndex].Compare (addDiff.NewItem) != DiffComparison.Different);
+                                 listA [x.OldIndex].Compare (addDiff.NewItem) != DiffComparison.Different);
 
                     if (rmDiff != null) {
                         addDiff.OldIndex = rmDiff.NewIndex;
                         rmDiff.Move = addDiff.Move = rmDiff.NewIndex < addDiff.NewIndex
-                            ? DiffMove.Forward : DiffMove.Backward;
+                                                     ? DiffMove.Forward : DiffMove.Backward;
                     }
                 }
             }

--- a/Phoebe/Data/Utils/TimeEntryGroup.cs
+++ b/Phoebe/Data/Utils/TimeEntryGroup.cs
@@ -79,5 +79,10 @@ namespace Toggl.Phoebe.Data.Utils
             }
             await Task.WhenAll (deleteTasks);
         }
+
+        public override string ToString ()
+        {
+            return string.Format ("[{0:MM/dd HH:mm}]", Data.StartTime);
+        }
     }
 }

--- a/Phoebe/Data/Utils/TimeEntryHolder.cs
+++ b/Phoebe/Data/Utils/TimeEntryHolder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Toggl.Phoebe.Data.DataObjects;
 using Toggl.Phoebe.Data.Models;
@@ -10,7 +11,42 @@ namespace Toggl.Phoebe.Data.Utils
     {
     }
 
-    // TODO: Check if this really needs to implement IDisposable
+    public class DateHolder : IHolder
+    {
+        public DateTime Date { get; }
+        public bool IsRunning { get; private set; }
+        public TimeSpan TotalDuration { get; private set; }
+
+        public DateHolder (DateTime date, IEnumerable<ITimeEntryHolder> timeHolders = null)
+        {
+            var totalDuration = TimeSpan.Zero;
+            var dataObjects = timeHolders != null ? timeHolders.ToList () : new List<ITimeEntryHolder> ();
+            foreach (var item in dataObjects) {
+                totalDuration += item.GetDuration ();
+            }
+
+            Date = date;
+            TotalDuration = totalDuration;
+            IsRunning = dataObjects.Any (g => g.Data.State == TimeEntryState.Running);
+        }
+
+        public DiffComparison Compare (IDiffComparable other)
+        {
+            var other2 = other as DateHolder;
+            if (other2 == null || other2.Date != Date) {
+                return DiffComparison.Different;
+            } else {
+                var same = other2.TotalDuration == TotalDuration && other2.IsRunning == IsRunning;
+                return same ? DiffComparison.Same : DiffComparison.Updated;
+            }
+        }
+
+        public override string ToString ()
+        {
+            return string.Format ("Date {0:dd/MM}", Date);
+        }
+    }
+
     public interface ITimeEntryHolder : IHolder
     {
         TimeEntryData Data { get; }


### PR DESCRIPTION
There was a problem with Move events which cause the target list did't update properly. This is because Move events consist of a Remove and an Add event that need to be applied at the same time but can have other events in between, so the indices get messed up. This has been fixed using offsets, see `TimeEntriesCollectionView.UpdateItemsAsync`.