### PR TITLE
Add cache to Diff algorithm

### DIFF
--- a/Phoebe/Data/Views/TimeEntriesCollectionView.cs
+++ b/Phoebe/Data/Views/TimeEntriesCollectionView.cs
@@ -229,7 +229,7 @@ namespace Toggl.Phoebe.Data.Views
                 var newItemCollection = CreateItemCollection (timeHolders);
 
                 // 4. Check diffs, modify ItemCollection and notify changes
-                var diffs = Diff.CalculateExtra (items, newItemCollection);
+                var diffs = Diff.Calculate (items, newItemCollection);
 
                 // CollectionChanged events must be fired on UI thread
                 ServiceContainer.Resolve<IPlatformUtils>().DispatchOnUIThread (() => {


### PR DESCRIPTION
Adds a cache to the Diff algorithm to prevent having to recalculate diff comparisons too many times and thus improve performance.