### PR TITLE
Replace Xamarin Insights with Raygun API

### DIFF
--- a/Joey/Analytics/Tracker.cs
+++ b/Joey/Analytics/Tracker.cs
@@ -4,7 +4,6 @@ using Android.Content;
 using Android.Gms.Analytics;
 using Toggl.Phoebe;
 using Toggl.Phoebe.Analytics;
-using Xamarin;
 
 namespace Toggl.Joey.Analytics
 {
@@ -36,7 +35,7 @@ namespace Toggl.Joey.Analytics
             SendHit (builder);
         }
 
-        protected override void SendTiming (long elapsedMilliseconds, string category, string variable, string label)
+        protected override void SendTiming (long elapsedMilliseconds, string category, string variable, string label = null)
         {
             SendHit (new HitBuilders.TimingBuilder ()
                      .SetValue (elapsedMilliseconds)
@@ -45,7 +44,7 @@ namespace Toggl.Joey.Analytics
                      .SetLabel (label));
         }
 
-        protected override void SendEvent (string category, string action, string label, long value)
+        protected override void SendEvent (string category, string action, string label = null, long value = 0)
         {
             SendHit (new HitBuilders.EventBuilder ()
                      .SetCategory (category)

--- a/Joey/Joey.csproj
+++ b/Joey/Joey.csproj
@@ -51,9 +51,6 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.Insights">
-      <HintPath>..\packages\Xamarin.Insights.1.11.1\lib\MonoAndroid10\Xamarin.Insights.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.Android.Support.v4">
       <HintPath>..\packages\Xamarin.Android.Support.v4.23.0.1.3\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
     </Reference>
@@ -116,6 +113,9 @@
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Analytics">
       <HintPath>..\packages\Xamarin.GooglePlayServices.Analytics.27.0.0.0\lib\MonoAndroid41\Xamarin.GooglePlayServices.Analytics.dll</HintPath>
+    </Reference>
+    <Reference Include="Mindscape.Raygun4Net.Xamarin.Android">
+      <HintPath>..\packages\Mindscape.Raygun4Net.5.2.0\lib\MonoAndroid2.2\Mindscape.Raygun4Net.Xamarin.Android.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -754,7 +754,6 @@
     <AndroidResource Include="Resources\layout\TimeEntryListFooter.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-  <Import Project="..\packages\Xamarin.Insights.1.11.1\build\MonoAndroid10\Xamarin.Insights.targets" Condition="Exists('..\packages\Xamarin.Insights.1.11.1\build\MonoAndroid10\Xamarin.Insights.targets')" />
   <ItemGroup>
     <ProjectReference Include="..\Phoebe\Phoebe.Android.csproj">
       <Project>{FF67B529-C11B-4FE0-AA1B-CD77141816BB}</Project>

--- a/Joey/packages.config
+++ b/Joey/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="MonoAndroid50" />
+  <package id="Mindscape.Raygun4Net" version="5.2.0" targetFramework="MonoAndroid50" />
   <package id="MvvmLightLibs" version="5.2.0.0" targetFramework="MonoAndroid50" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="MonoAndroid50" />
   <package id="SQLite.Net.Async-PCL" version="3.1.1" targetFramework="MonoAndroid50" />
@@ -20,5 +21,4 @@
   <package id="Xamarin.GooglePlayServices.Gcm" version="27.0.0.0" targetFramework="MonoAndroid50" />
   <package id="Xamarin.GooglePlayServices.Plus" version="27.0.0.0" targetFramework="MonoAndroid50" />
   <package id="Xamarin.GooglePlayServices.Wearable" version="27.0.0.0" targetFramework="MonoAndroid50" />
-  <package id="Xamarin.Insights" version="1.11.1" targetFramework="MonoAndroid50" />
 </packages>

--- a/Phoebe/Build.cs
+++ b/Phoebe/Build.cs
@@ -26,7 +26,7 @@ namespace Toggl.Phoebe
         #if __ANDROID__
         public static readonly string AppIdentifier = "TogglJoey";
         public static readonly string GcmSenderId = "";
-        public static readonly string XamInsightsApiKey = "";
+        public static readonly string RaygunApiKey = "";
         public static readonly string GooglePlayUrl = "https://play.google.com/store/apps/details?id=com.toggl.timer";
         #endif
         #endregion
@@ -36,7 +36,7 @@ namespace Toggl.Phoebe
         #if __IOS__
         public static readonly string AppIdentifier = "TogglRoss";
         public static readonly string AppStoreUrl = "itms-apps://itunes.com/apps/toggl";
-        public static readonly string XamInsightsApiKey = "";
+        public static readonly string RaygunApiKey = "";
         #endif
         #endregion
     }

--- a/Phoebe/Logging/ILoggerClient.cs
+++ b/Phoebe/Logging/ILoggerClient.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
 namespace Toggl.Phoebe.Logging
@@ -13,7 +12,7 @@ namespace Toggl.Phoebe.Logging
 
     public class Metadata : JObject
     {
-        public Metadata () : base ()
+        public Metadata ()
         {
         }
 
@@ -48,10 +47,6 @@ namespace Toggl.Phoebe.Logging
 
     public interface ILoggerClient
     {
-        string DeviceId { get; set; }
-
-        List<string> ProjectNamespaces { get; set; }
-
         void SetUser (string id, string email = null, string name = null);
 
         void Notify (Exception e, ErrorSeverity severity = ErrorSeverity.Error, Metadata extraMetadata = null);

--- a/Phoebe/Net/LoggerUserManager.cs
+++ b/Phoebe/Net/LoggerUserManager.cs
@@ -29,7 +29,7 @@ namespace Toggl.Phoebe.Net
                 loggerClient.SetUser (null, null, null);
             } else {
                 string id = user.RemoteId.HasValue ? user.RemoteId.ToString () : null;
-                loggerClient.SetUser (id, null, user.Name);
+                loggerClient.SetUser (id, user.Email, user.Name);
             }
         }
     }

--- a/Phoebe/Phoebe.Android.csproj
+++ b/Phoebe/Phoebe.Android.csproj
@@ -62,9 +62,6 @@
     <Reference Include="PropertyChanged">
       <HintPath>..\packages\PropertyChanged.Fody.1.50.3\Lib\portable-net4+sl4+wp8+win8+wpa81+MonoAndroid16+MonoTouch40\PropertyChanged.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.Insights">
-      <HintPath>..\packages\Xamarin.Insights.1.11.1\lib\MonoAndroid10\Xamarin.Insights.dll</HintPath>
-    </Reference>
     <Reference Include="System.Reactive.Interfaces">
       <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.Interfaces.dll</HintPath>
     </Reference>
@@ -76,6 +73,9 @@
     </Reference>
     <Reference Include="System.Reactive.PlatformServices">
       <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.PlatformServices.dll</HintPath>
+    </Reference>
+    <Reference Include="Mindscape.Raygun4Net4">
+      <HintPath>..\packages\Mindscape.Raygun4Net.5.2.0\lib\MonoAndroid2.2\Mindscape.Raygun4Net.Xamarin.Android.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Phoebe/Phoebe.Desktop.csproj
+++ b/Phoebe/Phoebe.Desktop.csproj
@@ -66,6 +66,9 @@
     <Reference Include="SQLite.Net.Async">
       <HintPath>..\packages\SQLite.Net.Async-PCL.3.1.1\lib\portable-win8+net45+wp8+wpa81+MonoAndroid1+MonoTouch1\SQLite.Net.Async.dll</HintPath>
     </Reference>
+    <Reference Include="Mindscape.Raygun4Net4">
+      <HintPath>..\packages\Mindscape.Raygun4Net.5.2.0\lib\net40\Mindscape.Raygun4Net.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Contrib\XPlatUtils\XPlatUtils\ServiceContainer.cs">

--- a/Phoebe/Phoebe.Desktop.csproj
+++ b/Phoebe/Phoebe.Desktop.csproj
@@ -14,7 +14,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Desktop\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
+    <DefineConstants>DEBUG;__TESTS__;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -31,9 +31,6 @@
     <Reference Include="System" />
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Insights">
-      <HintPath>..\packages\Xamarin.Insights.1.11.2\lib\net40\Xamarin.Insights.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Interfaces">
       <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.Interfaces.dll</HintPath>

--- a/Phoebe/Phoebe.iOS.csproj
+++ b/Phoebe/Phoebe.iOS.csproj
@@ -68,9 +68,6 @@
     <Reference Include="PropertyChanged">
       <HintPath>..\packages\PropertyChanged.Fody.1.50.3\Lib\portable-net4+sl4+wp8+win8+wpa81+MonoAndroid16+MonoTouch40\PropertyChanged.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.Insights">
-      <HintPath>..\packages\Xamarin.Insights.1.11.2\lib\Xamarin.iOS10\Xamarin.Insights.dll</HintPath>
-    </Reference>
     <Reference Include="PLCrashReporterUnifiedBinding">
       <HintPath>..\packages\Xamarin.Insights.1.11.2\lib\Xamarin.iOS10\PLCrashReporterUnifiedBinding.dll</HintPath>
     </Reference>
@@ -79,6 +76,9 @@
     </Reference>
     <Reference Include="SQLite.Net.Async">
       <HintPath>..\packages\SQLite.Net.Async-PCL.3.1.1\lib\portable-win8+net45+wp8+wpa81+MonoAndroid1+MonoTouch1\SQLite.Net.Async.dll</HintPath>
+    </Reference>
+    <Reference Include="Mindscape.Raygun4Net4">
+      <HintPath>..\packages\Mindscape.Raygun4Net.5.2.0\lib\Xamarin.iOS10\Mindscape.Raygun4Net.Xamarin.iOS.Unified.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Phoebe/packages.config
+++ b/Phoebe/packages.config
@@ -19,19 +19,21 @@
   <package id="SQLite.Net.Core-PCL" version="3.1.1" targetFramework="net45" />
   <package id="SQLite.Net.Core-PCL" version="3.1.1" targetFramework="xamarinios10" />
   <package id="Mindscape.Raygun4Net" version="5.2.0" targetFramework="net45" />
+  <package id="Mindscape.Raygun4Net" version="5.2.0" targetFramework="MonoAndroid403" />
+  <package id="Mindscape.Raygun4Net" version="5.2.0" targetFramework="xamarinios10" />
   <package id="Rx-Core" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-Main" version="2.2.5" targetFramework="MonoAndroid403" />
-  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoAndroid403" />  
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net40" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net40" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net40" />
   <package id="Rx-Main" version="2.2.5" targetFramework="net40" />
-  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net40" />  
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net40" />
   <package id="Rx-Core" version="2.2.5" targetFramework="xamarinios10" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="xamarinios10" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="xamarinios10" />
   <package id="Rx-Main" version="2.2.5" targetFramework="xamarinios10" />
-  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="xamarinios10" />  
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="xamarinios10" />
 </packages>

--- a/Phoebe/packages.config
+++ b/Phoebe/packages.config
@@ -18,9 +18,7 @@
   <package id="SQLite.Net.Core-PCL" version="3.1.1" targetFramework="MonoAndroid403" />
   <package id="SQLite.Net.Core-PCL" version="3.1.1" targetFramework="net45" />
   <package id="SQLite.Net.Core-PCL" version="3.1.1" targetFramework="xamarinios10" />
-  <package id="Xamarin.Insights" version="1.11.2" targetFramework="MonoAndroid403" />
-  <package id="Xamarin.Insights" version="1.11.2" targetFramework="net40" />
-  <package id="Xamarin.Insights" version="1.11.2" targetFramework="xamarinios10" />
+  <package id="Mindscape.Raygun4Net" version="5.2.0" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="MonoAndroid403" />

--- a/Ross/AppDelegate.cs
+++ b/Ross/AppDelegate.cs
@@ -1,9 +1,9 @@
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Foundation;
 using Google.Core;
 using Google.SignIn;
+using Mindscape.Raygun4Net;
 using SQLite.Net.Interop;
 using SQLite.Net.Platform.XamarinIOS;
 using Toggl.Phoebe;
@@ -18,7 +18,6 @@ using Toggl.Ross.Net;
 using Toggl.Ross.ViewControllers;
 using Toggl.Ross.Views;
 using UIKit;
-using Xamarin;
 using XPlatUtils;
 
 namespace Toggl.Ross
@@ -37,6 +36,11 @@ namespace Toggl.Ross
         {
             var versionString = UIDevice.CurrentDevice.SystemVersion;
             systemVersion = Convert.ToInt32 ( versionString.Split ( new [] {"."}, StringSplitOptions.None)[0]);
+
+            // Attach bug tracker
+            #if (!DEBUG)
+            RaygunClient.Attach (Build.RaygunApiKey);
+            #endif
 
             // Component initialisation.
             RegisterComponents ();
@@ -149,18 +153,7 @@ namespace Toggl.Ross
             ServiceContainer.Register<ExperimentManager> (() => new ExperimentManager (
                 typeof (Toggl.Phoebe.Analytics.Experiments),
                 typeof (Toggl.Ross.Analytics.Experiments)));
-            ServiceContainer.Register<ILoggerClient> (delegate {
-                return new LogClient (delegate {
-                    #if DEBUG
-                    Insights.Initialize (Insights.DebugModeKey);
-                    #else
-                    Insights.Initialize (Build.XamInsightsApiKey);
-                    #endif
-                }) {
-                    DeviceId = ServiceContainer.Resolve<SettingsStore> ().InstallId,
-                    ProjectNamespaces = new List<string> () { "Toggl." },
-                };
-            });
+            ServiceContainer.Register<ILoggerClient> (() => new LogClient ());
             ServiceContainer.Register<ITracker> (() => new Tracker());
             ServiceContainer.Register<INetworkPresence> (() => new NetworkPresence ());
             ServiceContainer.Register<NetworkIndicatorManager> ();

--- a/Ross/Ross.csproj
+++ b/Ross/Ross.csproj
@@ -134,12 +134,6 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.Insights">
-      <HintPath>..\packages\Xamarin.Insights.1.11.2\lib\Xamarin.iOS10\Xamarin.Insights.dll</HintPath>
-    </Reference>
-    <Reference Include="PLCrashReporterUnifiedBinding">
-      <HintPath>..\packages\Xamarin.Insights.1.11.2\lib\Xamarin.iOS10\PLCrashReporterUnifiedBinding.dll</HintPath>
-    </Reference>
     <Reference Include="Google.Core">
       <HintPath>..\packages\Xamarin.Google.iOS.Core.1.1.0.0\lib\Xamarin.iOS10\Google.Core.dll</HintPath>
     </Reference>
@@ -169,6 +163,9 @@
     </Reference>
     <Reference Include="GalaSoft.MvvmLight.Platform">
       <HintPath>..\packages\MvvmLightLibs.5.2.0.0\lib\xamarin.ios10\GalaSoft.MvvmLight.Platform.dll</HintPath>
+    </Reference>
+    <Reference Include="Mindscape.Raygun4Net.Xamarin.iOS.Unified">
+      <HintPath>..\packages\Mindscape.Raygun4Net.5.2.0\lib\Xamarin.iOS10\Mindscape.Raygun4Net.Xamarin.iOS.Unified.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -390,5 +387,4 @@
     <ITunesArtwork Include="iTunesArtwork%402x" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
-  <Import Project="..\packages\Xamarin.Insights.1.11.2\build\Xamarin.iOS10\Xamarin.Insights.targets" Condition="Exists('..\packages\Xamarin.Insights.1.11.2\build\Xamarin.iOS10\Xamarin.Insights.targets')" />
 </Project>

--- a/Ross/packages.config
+++ b/Ross/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="xamarinios10" />
+  <package id="Mindscape.Raygun4Net" version="5.2.0" targetFramework="xamarinios10" />
   <package id="MvvmLightLibs" version="5.2.0.0" targetFramework="xamarinios10" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="xamarinios10" />
   <package id="SQLite.Net.Async-PCL" version="3.1.1" targetFramework="xamarinios10" />
@@ -9,5 +10,4 @@
   <package id="Xamarin.Google.iOS.Analytics" version="3.13.0.0" targetFramework="xamarinios10" />
   <package id="Xamarin.Google.iOS.Core" version="1.1.0.0" targetFramework="xamarinios10" />
   <package id="Xamarin.Google.iOS.SignIn" version="2.3.1.0" targetFramework="xamarinios10" />
-  <package id="Xamarin.Insights" version="1.11.2" targetFramework="xamarinios10" />
 </packages>

--- a/Tests/UpgradeManagerTest.cs
+++ b/Tests/UpgradeManagerTest.cs
@@ -127,6 +127,8 @@ namespace Toggl.Phoebe.Tests
             public int? LastReportZoomViewed { get; set; }
 
             public bool GroupedTimeEntries { get; set; }
+
+            public bool SortProjectsBy { get; set; }
         }
     }
 }


### PR DESCRIPTION
- Tested in Android, not iOS (should work)
- Nuget tools in Xamarin didn't set the correct references, so I edited the .csproj files manually. Probably this will be needed again when creating the package.
- Apparently, Raygun doesn't have two different methods (Track and Report) to send messages, so I've used tags to make the distinction regarding severity.
- For the Desktop project, I've added a compiler directive to ignore the file, so there's no need to make a reference to Raygun. Another solution would be to register the LogClient from Joey and Ross.