### PR TITLE
Android wear app signed correctly in Teamcity

### DIFF
--- a/.build-helpers.fsx
+++ b/.build-helpers.fsx
@@ -1,4 +1,4 @@
-#r @"packages/FAKE.4.4.2/tools/FakeLib.dll"
+#r @"packages/FAKE.4.12.0/tools/FakeLib.dll"
 
 open Fake
 open Fake.XamarinHelper

--- a/.build.fsx
+++ b/.build.fsx
@@ -47,8 +47,8 @@ Target "android-signalign" (fun () ->
     // path configurations
     let basePath = "Joey/bin/Release/com.toggl.timer"
     let unsignedApk = basePath + ".apk"
-    let unsignedWereableApk = basePath + "/res/raw/wearable_app.apk"
-    let signedWereableApk = basePath + "_weareable_signed.apk"
+    let unsignedWearableApk = basePath + "/res/raw/wearable_app.apk"
+    let signedWearableApk = basePath + "_weareable_signed.apk"
 
     let ChangeFileName (file:FileInfo) =
         let newName = Path.Combine(file.DirectoryName, fileName)
@@ -60,15 +60,15 @@ Target "android-signalign" (fun () ->
     Shell.Exec ("apktool", unpackArgs) |> ignore
 
      // Sign wearable apk
-    let jarsignerArgs = String.Format("-verbose -keystore {0} -storepass {1} {2} {3}", keyStorePath, keyStorePassword, unsignedWereableApk, keyStoreAlias)
+    let jarsignerArgs = String.Format("-verbose -keystore {0} -storepass {1} {2} {3}", keyStorePath, keyStorePassword, unsignedWearableApk, keyStoreAlias)
     Shell.Exec ("jarsigner", jarsignerArgs) |> ignore
 
     // Pack solution again
-    let packArgs = String.Format("b -o {0} {1}", signedWereableApk, basePath)
+    let packArgs = String.Format("b -o {0} {1}", signedWearableApk, basePath)
     Shell.Exec ("apktool", packArgs) |> ignore
 
     // Sign whole .apk and finish process
-    let apkFileInfo = new FileInfo (signedWereableApk);
+    let apkFileInfo = new FileInfo (signedWearableApk);
     AndroidSignAndAlign (fun defaults ->
         {defaults with
             KeystorePath = keyStorePath

--- a/.build.fsx
+++ b/.build.fsx
@@ -1,4 +1,4 @@
-#r @"packages/FAKE.4.4.2/tools/FakeLib.dll"
+#r @"packages/FAKE.4.12.0/tools/FakeLib.dll"
 #load ".build-helpers.fsx"
 open Fake
 open System
@@ -25,45 +25,58 @@ Target "core-tests" (fun () ->
     RunNUnitTests "Tests/bin/Debug/Tests.dll" "Tests/bin/Debug/TestResult.xml"
 )
 
-Target "android-build" (fun () ->
+Target "android-package" (fun () ->
     let buildParamsFile = getBuildParam "buildParamsFile"
     if (System.String.Empty <> buildParamsFile)
       then cp buildParamsFile "Phoebe/Build.cs"
 
     RestorePackages "Mobile.Android.sln"
+    // Build solution to include Android Wear
     MSBuild "" "Build" [ ("Configuration", "Release") ] [ "Mobile.Android.sln" ] |> ignore
+    // Package project (wear apk will be included)
+    MSBuild "Joey/bin/Release" "PackageForAndroid" [ ("Configuration", "Release") ]  [ "Joey/Joey.csproj" ] |> ignore
 )
 
-Target "android-package" (fun () ->
+Target "android-signalign" (fun () ->
     // Android build parameters
     let keyStorePath = getBuildParamOrDefault "keyStorePath" "toggl.keystore"
     let keyStorePassword = getBuildParamOrDefault "keyStorePassword" ""
     let keyStoreAlias = getBuildParamOrDefault "keyStoreAlias" "toggl"
     let fileName = GetAndroidReleaseName "Joey/Properties/AndroidManifest.xml"
 
+    // path configurations
+    let basePath = "Joey/bin/Release/com.toggl.timer"
+    let unsignedApk = basePath + ".apk"
+    let unsignedWereableApk = basePath + "/res/raw/wearable_app.apk"
+    let signedWereableApk = basePath + "_weareable_signed.apk"
+
     let ChangeFileName (file:FileInfo) =
         let newName = Path.Combine(file.DirectoryName, fileName)
         file.MoveTo (newName)
         newName
 
-    AndroidPackage (fun defaults ->
-        {defaults with
-            ProjectPath = "Joey/Joey.csproj" // Project file and not Android solution!
-            Configuration = "Release"
-            OutputPath = "Joey/bin/Release"
-        })
-    |> AndroidSignAndAlign (fun defaults ->
+    // Unpack the unsigned apk
+    let unpackArgs = String.Format("d -s -o {0} {1}", basePath, unsignedApk)
+    Shell.Exec ("apktool", unpackArgs) |> ignore
+
+     // Sign wearable apk
+    let jarsignerArgs = String.Format("-verbose -keystore {0} -storepass {1} {2} {3}", keyStorePath, keyStorePassword, unsignedWereableApk, keyStoreAlias)
+    Shell.Exec ("jarsigner", jarsignerArgs) |> ignore
+
+    // Pack solution again
+    let packArgs = String.Format("b -o {0} {1}", signedWereableApk, basePath)
+    Shell.Exec ("apktool", packArgs) |> ignore
+
+    // Sign whole .apk and finish process
+    let apkFileInfo = new FileInfo (signedWereableApk);
+    AndroidSignAndAlign (fun defaults ->
         {defaults with
             KeystorePath = keyStorePath
             KeystorePassword = keyStorePassword
             KeystoreAlias = keyStoreAlias
-            // If zipalign tool is not added to system path
-            // you should uncomment this line and configure
-            // the correct path.
-            // ZipalignPath = "/Users/xxx/Library/Developers/Xamarin/android-sdk-macosx/build-tools/23.0.0/zipalign"
-        })
+        }) apkFileInfo
     |> ChangeFileName
-    |> TeamCityHelper.PublishArtifact
+    |> TeamCityHelper.PublishArtifact 
 )
 
 Target "ios-build" (fun () ->
@@ -163,8 +176,8 @@ Target "ios-appstore" (fun () ->
   ==> "core-tests"
 
 "clean"
-  ==> "android-build"
   ==> "android-package"
+  ==> "android-signalign"
 
 "clean"
   ==> "ios-build"

--- a/.build.sh
+++ b/.build.sh
@@ -7,6 +7,6 @@ if [[ ! -e ${NUGET} ]]; then
     curl -o ${NUGET} https://az320820.vo.msecnd.net/downloads/nuget.exe
 fi
 
-mono --runtime=v4.0 ${NUGET} install FAKE -Version 4.4.2 -OutputDirectory packages
+mono --runtime=v4.0 ${NUGET} install FAKE -Version 4.12.0 -OutputDirectory packages
 mono --runtime=v4.0 ${NUGET} install NUnit.Runners -Version 2.6.4 -OutputDirectory packages
 mono --runtime=v4.0 packages/FAKE.4.4.2/tools/FAKE.exe .build.fsx $@

--- a/Joey/Joey.csproj
+++ b/Joey/Joey.csproj
@@ -26,9 +26,9 @@
     <DefineConstants>DEBUG;__MOBILE__;__ANDROID__;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AndroidLinkMode>None</AndroidLinkMode>
     <ConsolePause>false</ConsolePause>
     <EmbedAssembliesIntoApk>False</EmbedAssembliesIntoApk>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -38,9 +38,10 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <AndroidLinkMode>Full</AndroidLinkMode>
-    <AndroidLinkSkip>Bugsnag;Bugsnag.Android;Phoebe;Joey</AndroidLinkSkip>
+    <AndroidLinkSkip>Phoebe;Joey;System.Reactive.Core;System.Reactive.Linq;</AndroidLinkSkip>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <DebugType>full</DebugType>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Phoebe/Phoebe.Desktop.csproj
+++ b/Phoebe/Phoebe.Desktop.csproj
@@ -67,7 +67,7 @@
       <HintPath>..\packages\SQLite.Net.Async-PCL.3.1.1\lib\portable-win8+net45+wp8+wpa81+MonoAndroid1+MonoTouch1\SQLite.Net.Async.dll</HintPath>
     </Reference>
     <Reference Include="Mindscape.Raygun4Net4">
-      <HintPath>..\packages\Mindscape.Raygun4Net.5.2.0\lib\net40\Mindscape.Raygun4Net.dll</HintPath>
+      <HintPath>..\packages\Mindscape.Raygun4Net.5.2.0\lib\MonoAndroid2.2\Mindscape.Raygun4Net.Xamarin.Android.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/UpgradeManagerTest.cs
+++ b/Tests/UpgradeManagerTest.cs
@@ -128,7 +128,7 @@ namespace Toggl.Phoebe.Tests
 
             public bool GroupedTimeEntries { get; set; }
 
-            public bool SortProjectsBy { get; set; }
+            public string SortProjectsBy { get; set; }
         }
     }
 }


### PR DESCRIPTION
The Android wear app (Chandler) was not installed because the wearable-app.apk (inside res/raw/) was not correctly signed. I have changed the process of *build* to:
- build an unsigned .apk including the wearable apk (Chandler project) and all conf files needed.
- unpack the unsigned apk
- sign the wearable apk correctly.
- pack again and sign the container apk (Joey project) and align the zip.

Seems to be Xamarin Studio does the process in this way. Now we need to test that the app is installed correctly in wear device.