### PR TITLE
Await ViewModel creation in EditTimeEntryFragment.OnActivityResult

### DIFF
--- a/Joey/UI/Fragments/EditGroupedTimeEntryFragment.cs
+++ b/Joey/UI/Fragments/EditGroupedTimeEntryFragment.cs
@@ -104,8 +104,6 @@ namespace Toggl.Joey.UI.Fragments
                            .SetHint (Resource.String.EditTimeEntryFragmentProjectHint)
                            .SimulateButton();
 
-            ProjectField.TextField.Click += OnProjectEditTextClick;
-            ProjectField.Click += OnProjectEditTextClick;
             timeEntriesListView = view.FindViewById<ListView> (Resource.Id.timeEntryGroupListView);
 
             HasOptionsMenu = true;
@@ -116,6 +114,9 @@ namespace Toggl.Joey.UI.Fragments
         {
             base.OnViewCreated (view, savedInstanceState);
             ViewModel = await EditTimeEntryGroupViewModel.Init (TimeEntryIds.ToList ());
+
+            ProjectField.TextField.Click += OnProjectEditTextClick;
+            ProjectField.Click += OnProjectEditTextClick;
 
             durationBinding = this.SetBinding (() => ViewModel.Duration, () => DurationTextView.Text);
             startTimeBinding = this.SetBinding (() => ViewModel.StartDate, () => StartTimeEditText.Text).ConvertSourceToTarget (dateTime => dateTime.ToDeviceTimeString ());
@@ -174,13 +175,15 @@ namespace Toggl.Joey.UI.Fragments
             StartActivityForResult (intent, 0);
         }
 
-        public override void OnActivityResult (int requestCode, int resultCode, Intent data)
+        public override async void OnActivityResult (int requestCode, int resultCode, Intent data)
         {
             base.OnActivityResult (requestCode, resultCode, data);
             if (resultCode == (int)Result.Ok) {
                 var taskId = GetGuidFromIntent (data, BaseActivity.IntentTaskIdArgument);
                 var projectId = GetGuidFromIntent (data, BaseActivity.IntentProjectIdArgument);
-                ViewModel.SetProjectAndTask (projectId, taskId);
+
+                await Util.AwaitPredicate (() => ViewModel != null);
+                await ViewModel.SetProjectAndTask (projectId, taskId);
             }
         }
 

--- a/Joey/UI/Fragments/EditTimeEntryFragment.cs
+++ b/Joey/UI/Fragments/EditTimeEntryFragment.cs
@@ -13,6 +13,7 @@ using Toggl.Joey.Data;
 using Toggl.Joey.UI.Activities;
 using Toggl.Joey.UI.Utils;
 using Toggl.Joey.UI.Views;
+using Toggl.Phoebe;
 using Toggl.Phoebe.Data.DataObjects;
 using Toggl.Phoebe.Data.ViewModels;
 using XPlatUtils;
@@ -215,30 +216,6 @@ namespace Toggl.Joey.UI.Fragments
             StartActivityForResult (intent, 0);
         }
 
-        Task<bool> AwaitPredicate (Func<bool> predicate, double interval = 100, double timeout = 5000)
-        {
-            var tcs = new TaskCompletionSource<bool> ();
-
-            double timePassed = 0;
-            var timer = new System.Timers.Timer (interval)  { AutoReset = true };
-            timer.Elapsed += (s, e) => {
-                timePassed += interval;
-                if (timePassed >= timeout) {
-                    timer.Stop ();
-                    tcs.SetResult (false);
-                } else {
-                    var success = predicate ();
-                    if (success) {
-                        timer.Stop ();
-                        tcs.SetResult (true);
-                    }
-                }
-            };
-            timer.Start ();
-
-            return tcs.Task;
-        }
-
         public override async void OnActivityResult (int requestCode, int resultCode, Intent data)
         {
             base.OnActivityResult (requestCode, resultCode, data);
@@ -246,7 +223,7 @@ namespace Toggl.Joey.UI.Fragments
                 var taskId = GetGuidFromIntent (data, BaseActivity.IntentTaskIdArgument);
                 var projectId = GetGuidFromIntent (data, BaseActivity.IntentProjectIdArgument);
 
-                await AwaitPredicate (() => ViewModel != null);
+                await Util.AwaitPredicate (() => ViewModel != null);
                 await ViewModel.SetProjectAndTask (projectId, taskId);
             }
         }

--- a/Joey/UI/Fragments/EditTimeEntryFragment.cs
+++ b/Joey/UI/Fragments/EditTimeEntryFragment.cs
@@ -291,29 +291,5 @@ namespace Toggl.Joey.UI.Fragments
                 SaveMenuItem.SetVisible (ViewModel.IsManual);
             }
         }
-
-        private Task<bool> AwaitPredicate (Func<bool> predicate, double interval = 100, double timeout = 5000)
-        {
-            var tcs = new TaskCompletionSource<bool> ();
-
-            double timePassed = 0;
-            var timer = new System.Timers.Timer (interval)  { AutoReset = true };
-            timer.Elapsed += (s, e) => {
-                timePassed += interval;
-                if (timePassed >= timeout) {
-                    timer.Stop ();
-                    tcs.SetResult (false);
-                } else {
-                    var success = predicate ();
-                    if (success) {
-                        timer.Stop ();
-                        tcs.SetResult (true);
-                    }
-                }
-            };
-            timer.Start ();
-
-            return tcs.Task;
-        }
     }
 }

--- a/Phoebe/Util.cs
+++ b/Phoebe/Util.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Toggl.Phoebe
+{
+    public static class Util
+    {
+        public static Task<bool> AwaitPredicate (Func<bool> predicate, double interval = 100, double timeout = 5000)
+        {
+            var tcs = new TaskCompletionSource<bool> ();
+
+            double timePassed = 0;
+            var timer = new System.Timers.Timer (interval)  { AutoReset = true };
+            timer.Elapsed += (s, e) => {
+                timePassed += interval;
+                if (timePassed >= timeout) {
+                    timer.Stop ();
+                    tcs.SetResult (false);
+                } else {
+                    var success = predicate ();
+                    if (success) {
+                        timer.Stop ();
+                        tcs.SetResult (true);
+                    }
+                }
+            };
+            timer.Start ();
+
+            return tcs.Task;
+        }
+    }
+}


### PR DESCRIPTION
- Also move event hooks after ViewModel creation.
- `AwaitPredicate` should probably be moved to an utility class.

Fixes (partly) #1139.