### PR TITLE
Fixes #1144 (Time Entry Groups didn't update project properly)

### DIFF
--- a/Phoebe/Data/DataExtensions.cs
+++ b/Phoebe/Data/DataExtensions.cs
@@ -95,6 +95,7 @@ namespace Toggl.Phoebe.Data
             return existingProjects.Count != 0;
         }
 
+        // TODO: Check also IsBillable, Tags?
         public static bool IsGroupableWith (this TimeEntryData data, TimeEntryData other)
         {
             return data.ProjectId == other.ProjectId &&

--- a/Phoebe/Data/Utils/ObservableRangeCollection.cs
+++ b/Phoebe/Data/Utils/ObservableRangeCollection.cs
@@ -24,10 +24,13 @@ namespace Toggl.Phoebe.Data.Utils
 
         public void Move (int oldIndex, int newIndex, T updatedItem)
         {
+            var oldItem = Items [oldIndex];
             Items.RemoveAt (oldIndex);
             Items.Insert (newIndex, updatedItem);
             OnCollectionChanged (new NotifyCollectionChangedEventArgs (
                                      NotifyCollectionChangedAction.Move, updatedItem, newIndex, oldIndex));
+            OnCollectionChanged (new NotifyCollectionChangedEventArgs (
+                                     NotifyCollectionChangedAction.Replace, updatedItem, oldItem, newIndex));
         }
 
         public void InsertRange (IEnumerable<T> collection, int startingIndex)

--- a/Phoebe/Data/Utils/TimeEntriesCollection.cs
+++ b/Phoebe/Data/Utils/TimeEntriesCollection.cs
@@ -12,21 +12,21 @@ using XPlatUtils;
 
 namespace Toggl.Phoebe.Data.Utils
 {
-    public class TimeEntriesCollection : ObservableRangeCollection<IHolder>, ICollectionData<IHolder>
+    public class TimeEntriesCollection<T>
+        : ObservableRangeCollection<IHolder>, ICollectionData<IHolder> where T : ITimeEntryHolder
     {
         private IDisposable disposable;
-        private readonly bool isGrouped;
         private readonly bool loadTimeEntryInfo;
+        private readonly IGrouper<TimeEntryHolder, T> grouper;
 
         public IEnumerable<IHolder> Data
         {
             get { return Items; }
         }
 
-        public TimeEntriesCollection (IObservable<TimeEntryMessage> feed, bool isGrouped,
-                                      int bufferMilliseconds = 500, bool useThreadPool = true, bool loadTimeEntryInfo = true)
+        public TimeEntriesCollection (IObservable<TimeEntryMessage> feed, int bufferMilliseconds = 500, bool useThreadPool = true, bool loadTimeEntryInfo = true)
         {
-            this.isGrouped = isGrouped;
+            this.grouper = CreateGrouper ();;
             this.loadTimeEntryInfo = loadTimeEntryInfo;
 
             disposable =
@@ -54,15 +54,15 @@ namespace Toggl.Phoebe.Data.Utils
         private async Task UpdateItemsAsync (IEnumerable<TimeEntryMessage> msgs)
         {
             // 1. Get only TimeEntryHolders from current collection
-            var timeHolders = Items.OfType<ITimeEntryHolder> ().ToList ();
+            var timeHolders = grouper.Disgroup (Items.OfType<T> ()).ToList ();
 
             // 2. Remove, replace or add items from messages
             foreach (var msg in msgs) {
-                UpdateTimeHoldersAsync (timeHolders, msg.Data, msg.Action);
+                UpdateTimeHolders (timeHolders, msg.Data, msg.Action);
             }
 
             // 3. Create the new item collection from holders (sort and add headers...)
-            var newItemCollection = await CreateItemCollection (timeHolders, loadTimeEntryInfo);
+            var newItemCollection = await CreateItemCollectionAsync (timeHolders, loadTimeEntryInfo);
 
             // 4. Check diffs, modify ItemCollection and notify changes
             var diffs = Diff.Calculate (Items, newItemCollection);
@@ -88,54 +88,52 @@ namespace Toggl.Phoebe.Data.Utils
             });
         }
 
-        private void UpdateTimeHoldersAsync (IList<ITimeEntryHolder> timeHolders, TimeEntryData entry, DataAction action)
+        private void UpdateTimeHolders (List<TimeEntryHolder> timeHolders, TimeEntryData entry, DataAction action)
         {
-            if (action == DataAction.Put) {
-                var foundIndex = timeHolders.IndexOf (x => x.IsAffectedByPut (entry));
-                if (foundIndex > -1) {
-                    timeHolders [foundIndex] = CreateTimeHolder (isGrouped, entry, timeHolders [foundIndex]); // Replace
-                } else {
-                    timeHolders.Add (CreateTimeHolder (isGrouped, entry)); // Insert
-                }
-            } else {
-                bool isAffectedByDelete;
-                for (var i = 0; i < timeHolders.Count; i++) {
-                    var updatedHolder = timeHolders [i].UpdateOrDelete (entry, out isAffectedByDelete);
-
-                    if (isAffectedByDelete) {
-                        if (updatedHolder == null) {
-                            timeHolders.RemoveAt (i); // Remove
-                        } else {
-                            timeHolders [i] = updatedHolder; // Replace
-                        }
-                        break;
+            for (var i = 0; i < timeHolders.Count; i++) {
+                if (entry.Id == timeHolders [i].Data.Id) {
+                    if (action == DataAction.Put) {
+                        timeHolders [i] = new TimeEntryHolder (entry); // Replace
+                    } else {
+                        timeHolders.RemoveAt (i); // Remove
                     }
+                    return;
                 }
+            }
+
+            if (action == DataAction.Put) {
+                timeHolders.Add (new TimeEntryHolder (entry)); // Add
             }
         }
 
-        public static async Task<IList<IHolder>> CreateItemCollection (IEnumerable<ITimeEntryHolder> timeHolders, bool loadTimeEntryInfo)
+        public async Task<IList<IHolder>> CreateItemCollectionAsync (IEnumerable<TimeEntryHolder> timeHolders, bool loadTimeEntryInfo)
         {
-            var timeHolders2 = timeHolders;
+            IEnumerable<T> timeHolders2 = null;
             if (loadTimeEntryInfo) {
-                timeHolders2 = await Task.WhenAll (timeHolders.Select (async x => {
+                timeHolders2 = await Task.WhenAll (grouper.Group (timeHolders).Select (async x => {
                     await x.LoadInfoAsync ();
                     return x;
                 }));
+            } else {
+                timeHolders2 = grouper.Group (timeHolders);
             }
 
             return timeHolders2
                    .OrderByDescending (x => x.GetStartTime ())
                    .GroupBy (x => x.GetStartTime ().ToLocalTime().Date)
-                   .SelectMany (gr => gr.Cast<IHolder>().Prepend (new DateHolder (gr.Key, gr)))
+                   .SelectMany (gr => gr.Cast<IHolder>().Prepend (new DateHolder (gr.Key, gr.Cast<ITimeEntryHolder> ())))
                    .ToList ();
         }
 
-        public static ITimeEntryHolder CreateTimeHolder (bool isGrouped, TimeEntryData entry, ITimeEntryHolder previous = null)
+        private IGrouper<TimeEntryHolder, T> CreateGrouper ()
         {
-            return isGrouped
-                   ? (ITimeEntryHolder)new TimeEntryGroup (entry, previous)
-                   : new TimeEntryHolder (entry);
+            if (typeof (T) == typeof (TimeEntryGroup)) {
+                return (IGrouper<TimeEntryHolder, T>)new TimeEntryGroup.Grouper ();
+            } else if (typeof (T) == typeof (TimeEntryHolder)) {
+                return (IGrouper<TimeEntryHolder, T>)new TimeEntryHolder.Grouper ();
+            } else {
+                throw new NotSupportedException ();
+            }
         }
     }
 }

--- a/Phoebe/Data/Utils/TimeEntriesCollection.cs
+++ b/Phoebe/Data/Utils/TimeEntriesCollection.cs
@@ -54,7 +54,7 @@ namespace Toggl.Phoebe.Data.Utils
         private async Task UpdateItemsAsync (IEnumerable<TimeEntryMessage> msgs)
         {
             // 1. Get only TimeEntryHolders from current collection
-            var timeHolders = grouper.Disgroup (Items.OfType<T> ()).ToList ();
+            var timeHolders = grouper.Ungroup (Items.OfType<T> ()).ToList ();
 
             // 2. Remove, replace or add items from messages
             foreach (var msg in msgs) {

--- a/Phoebe/Data/Utils/TimeEntryGroup.cs
+++ b/Phoebe/Data/Utils/TimeEntryGroup.cs
@@ -30,7 +30,7 @@ namespace Toggl.Phoebe.Data.Utils
                     yield return new TimeEntryGroup (kvPair.Value.Select (x => x.Data), cached != null ? cached.Info : null);
                 }
             }
-            public IEnumerable<TimeEntryHolder> Disgroup (IEnumerable<TimeEntryGroup> groups)
+            public IEnumerable<TimeEntryHolder> Ungroup (IEnumerable<TimeEntryGroup> groups)
             {
                 foreach (var g in groups) {
                     foreach (var data in g.DataCollection) {

--- a/Phoebe/Data/Utils/TimeEntryGroup.cs
+++ b/Phoebe/Data/Utils/TimeEntryGroup.cs
@@ -78,7 +78,7 @@ namespace Toggl.Phoebe.Data.Utils
                 if (DataCollection.SequenceEqual (other2.DataCollection, object.ReferenceEquals)) {
                     return DiffComparison.Same;
                 } else {
-                    return other2.DataCollection.Last ().Id == DataCollection.Last ().Id
+                    return Data.IsGroupableWith (other2.Data)
                            ? DiffComparison.Update : DiffComparison.Different;
                 }
             } else {

--- a/Phoebe/Data/Utils/TimeEntryGroup.cs
+++ b/Phoebe/Data/Utils/TimeEntryGroup.cs
@@ -36,8 +36,8 @@ namespace Toggl.Phoebe.Data.Utils
                 Group = previous2.Group.ReplaceOrAppend (data, x => x.Id == data.Id)
                         .OrderByDescending (x => x.StartTime).ToList ();
 
-                // Recycle entry info if possible
-                Info = previous2.Data.Id == Data.Id ? previous2.Info : null;
+                // Recycle entry info if possible (IsGroupableWith method is used to check info hasn't changed)
+                Info = previous2.Data.Id == Data.Id && previous2.Data.IsGroupableWith (Data) ? previous2.Info : null;
             } else {
                 Group = new List<TimeEntryData> { data };
             }
@@ -82,7 +82,7 @@ namespace Toggl.Phoebe.Data.Utils
 
         public bool IsAffectedByPut (TimeEntryData data)
         {
-            return Group.Any (x => x.IsGroupableWith (data));
+            return Group.Any (x => x.Id == data.Id || x.IsGroupableWith (data));
         }
 
         public DateTime GetStartTime()

--- a/Phoebe/Data/Utils/TimeEntryHolder.cs
+++ b/Phoebe/Data/Utils/TimeEntryHolder.cs
@@ -6,6 +6,12 @@ using Toggl.Phoebe.Data.Models;
 
 namespace Toggl.Phoebe.Data.Utils
 {
+    public interface IGrouper<T, TGroup>
+    {
+        IEnumerable<TGroup> Group (IEnumerable<T> items);
+        IEnumerable<T> Disgroup (IEnumerable<TGroup> groups);
+    }
+
     public interface IHolder : IDiffComparable
     {
     }
@@ -20,12 +26,22 @@ namespace Toggl.Phoebe.Data.Utils
         Task LoadInfoAsync ();
         TimeSpan GetDuration ();
         DateTime GetStartTime ();
-        bool IsAffectedByPut (TimeEntryData data);
-        ITimeEntryHolder UpdateOrDelete (TimeEntryData data, out bool isAffectedByDelete);
     }
 
     public class TimeEntryHolder : ITimeEntryHolder
     {
+        public class Grouper : IGrouper<TimeEntryHolder, TimeEntryHolder>
+        {
+            public IEnumerable<TimeEntryHolder> Group (IEnumerable<TimeEntryHolder> items)
+            {
+                return items;
+            }
+            public IEnumerable<TimeEntryHolder> Disgroup (IEnumerable<TimeEntryHolder> groups)
+            {
+                return groups;
+            }
+        }
+
         public TimeEntryData Data { get; private set; }
         public TimeEntryInfo Info { get; private set; }
 
@@ -36,20 +52,15 @@ namespace Toggl.Phoebe.Data.Utils
             }
         }
 
-        public TimeEntryHolder (TimeEntryData data)
+        public TimeEntryHolder (TimeEntryData data, TimeEntryInfo info = null)
         {
             Data = data;
+            Info = info;
         }
 
         public async Task LoadInfoAsync ()
         {
             Info = await TimeEntryInfo.LoadAsync (Data);
-        }
-
-        public ITimeEntryHolder UpdateOrDelete (TimeEntryData data, out bool isAffectedByDelete)
-        {
-            isAffectedByDelete = data.Id == Data.Id;
-            return null; // Always delete if affected
         }
 
         public DiffComparison Compare (IDiffComparable other)
@@ -61,11 +72,6 @@ namespace Toggl.Phoebe.Data.Utils
                 return other2 != null && other2.Data.Id == Data.Id
                        ? DiffComparison.Update : DiffComparison.Different;
             }
-        }
-
-        public bool IsAffectedByPut (TimeEntryData data)
-        {
-            return data.Id == Data.Id;
         }
 
         public DateTime GetStartTime()

--- a/Phoebe/Data/Utils/TimeEntryHolder.cs
+++ b/Phoebe/Data/Utils/TimeEntryHolder.cs
@@ -9,7 +9,7 @@ namespace Toggl.Phoebe.Data.Utils
     public interface IGrouper<T, TGroup>
     {
         IEnumerable<TGroup> Group (IEnumerable<T> items);
-        IEnumerable<T> Disgroup (IEnumerable<TGroup> groups);
+        IEnumerable<T> Ungroup (IEnumerable<TGroup> groups);
     }
 
     public interface IHolder : IDiffComparable
@@ -36,7 +36,7 @@ namespace Toggl.Phoebe.Data.Utils
             {
                 return items;
             }
-            public IEnumerable<TimeEntryHolder> Disgroup (IEnumerable<TimeEntryHolder> groups)
+            public IEnumerable<TimeEntryHolder> Ungroup (IEnumerable<TimeEntryHolder> groups)
             {
                 return groups;
             }

--- a/Phoebe/Data/ViewModels/LogTimeEntriesViewModel.cs
+++ b/Phoebe/Data/ViewModels/LogTimeEntriesViewModel.cs
@@ -196,8 +196,9 @@ namespace Toggl.Phoebe.Data.ViewModels
             IsGroupedMode = ServiceContainer.Resolve<ISettingsStore> ().GroupedTimeEntries;
 
             collectionFeed = new TimeEntriesFeed ();
-            var col = new TimeEntriesCollection (collectionFeed, IsGroupedMode);
-            Collection = col;
+            Collection = IsGroupedMode
+                         ? (ICollectionData<IHolder>)new TimeEntriesCollection<TimeEntryGroup> (collectionFeed)
+                         : new TimeEntriesCollection<TimeEntryHolder> (collectionFeed);
         }
 
         private void UpdateView ()

--- a/Phoebe/LinqExtensions.cs
+++ b/Phoebe/LinqExtensions.cs
@@ -62,6 +62,18 @@ namespace Toggl.Phoebe
             return true;
         }
 
+        public static bool TryFindKey<TKey, TValue> (this IDictionary<TKey, TValue> dic,
+                out TKey result, Func<KeyValuePair<TKey, TValue>, bool> predicate)
+        {
+            foreach (var kv in dic) {
+                if (predicate (kv)) {
+                    result = kv.Key;
+                    return true;
+                }
+            }
+            result = default (TKey);
+            return false;
+        }
 
         public static IEnumerable<T> CollapsePairs<T> (this IEnumerable<T> items, Func<T,T,T> collapse)
         where T : class

--- a/Tests/Data/TimeEntriesCollectionTest.cs
+++ b/Tests/Data/TimeEntriesCollectionTest.cs
@@ -268,6 +268,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (entry2, DataAction.Put);
             });
 
+            Assert.AreEqual (evs.Count, 4);
             AssertList (singleView, dt, entry2, entry1);
 
             // Events after first push
@@ -301,6 +302,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (entries[4], DataAction.Delete);  // Delete entry
             });
 
+            Assert.AreEqual (evs.Count, 4);
             AssertList (singleView, dt, entries[0], dt.AddDays (-1), entries[3], entries[1]);
 
             AssertEvent (evs[0], "replace", "date header"); // Update today's header
@@ -331,6 +333,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (entries[1], DataAction.Delete); // Delete entry
             });
 
+            Assert.AreEqual (evs.Count, 5);
             AssertList (singleView, dt.AddDays (1), entries[3], dt, entries[2], entries[4]);
 
             AssertEvent (evs[0], "replace", "date header"); // Update today's header
@@ -360,6 +363,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (entry5, DataAction.Put); // Add entry
             });
 
+            Assert.AreEqual (evs.Count, 4);
             AssertList (singleView, dt, entry1, entry3, dt.AddDays (-1), entry4, entry2, entry5);
 
             AssertEvent (evs[0], "add", "time entry");
@@ -388,6 +392,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (CreateTimeEntry (entry4, 1), DataAction.Put); // Move entry to next day
             });
 
+            Assert.AreEqual (evs.Count, 5);
             AssertList (singleView, dt.AddDays (1), entry1, entry4, entry2, dt, entry3, entry5);
 
             AssertEvent (evs[0], "add", "date header");
@@ -421,6 +426,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (CreateTimeEntry (entry2, daysOffset: -1), DataAction.Put);
             });
 
+            Assert.AreEqual (evs.Count, 6);
             AssertList (singleView, dt, entry3, dt.AddDays (-1), entry2, entry5, entry4);
 
             AssertEvent (evs[0], "replace", "date header");
@@ -454,6 +460,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (CreateTimeEntry (entry5, daysOffset: 1), DataAction.Put);
             });
 
+            Assert.AreEqual (evs.Count, 7);
             AssertList (singleView, dt, entry3, entry1, entry2, entry5, dt.AddDays (-1), entry6);
 
             AssertEvent (evs[0], "replace", "date header");
@@ -485,6 +492,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (entry4, DataAction.Delete);
             });
 
+            Assert.AreEqual (evs.Count, 6);
             AssertList (singleView, dt, entry3, entry2, dt.AddDays (-1), entry1);
 
             AssertEvent (evs[0], "replace", "date header");
@@ -517,6 +525,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (CreateTimeEntry (entries[4], 0, 2), DataAction.Put);
             });
 
+            Assert.AreEqual (evs.Count, 3);
             AssertList (singleView, dt, entries[0], entries[1], entries[2], entries[3], dt.AddDays (-1), entries[4]);
 
             // The date header doesn't change because total duration remains the same
@@ -546,7 +555,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (CreateTimeEntry (entry1, daysOffset: 1), DataAction.Put);
             });
 
-            // Check if date has changed
+            Assert.AreEqual (evs.Count, 4);
             AssertList (singleView, dt.AddDays (1), entry1, entry2);
 
             AssertEvent (evs[0], "remove", "date header"); // Remove old header
@@ -575,10 +584,9 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (CreateTimeEntry (entry2, daysOffset: -1), DataAction.Put);
             });
 
-            // Order check after update
+            Assert.AreEqual (evs.Count, 4);
             AssertList (singleView, dt.AddDays (-1), entry1, entry2);
 
-            Assert.LessOrEqual (evs.Count, 4);
             AssertEvent (evs[0], "remove", "date header"); // Remove old header
             AssertEvent (evs[1], "add",    "date header"); // Add new header
             AssertEvent (evs[2], "replace", "time entry"); // Replace entry1
@@ -603,7 +611,7 @@ namespace Toggl.Phoebe.Tests.Data
                                        // Move first entry to previous day
                                        feed.Push (CreateTimeEntry (entry1, daysOffset: -1), DataAction.Put));
 
-            // Order check after update
+            Assert.AreEqual (evs.Count, 3);
             AssertList (singleView, dt, entry2, dt.AddDays (-1), entry1, entry3);
 
             AssertEvent (evs[0], "replace", "date header");
@@ -630,7 +638,7 @@ namespace Toggl.Phoebe.Tests.Data
                                        // Move first entry to previous day
                                        feed.Push (CreateTimeEntry (entry1, daysOffset: -1), DataAction.Put));
 
-            // Order check after update
+            Assert.AreEqual (evs.Count, 3);
             AssertList (singleView, dt, entry2, entry3, entry4, dt.AddDays (-1), entry1);
 
             AssertEvent (evs[0], "replace", "date header"); // Update old header
@@ -657,7 +665,7 @@ namespace Toggl.Phoebe.Tests.Data
                                        // Move first entry to next day
                                        feed.Push (CreateTimeEntry (entry4, daysOffset: 1), DataAction.Put));
 
-            // Order check after update
+            Assert.AreEqual (evs.Count, 3);
             AssertList (singleView, dt.AddDays (1), entry4, dt, entry1, entry2, entry3);
 
             AssertEvent (evs[0], "add", "date header");     // Add new header
@@ -684,7 +692,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (CreateTimeEntry (entry3, minutesOffset: 10), DataAction.Put);
             });
 
-            // Order check after update
+            Assert.AreEqual (evs.Count, 3);
             AssertList (singleView, dt, entry3, entry1, entry2);
 
             AssertEvent (evs[0], "move", "time entry");    // Move time entry3
@@ -711,6 +719,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (entry3, DataAction.Put);
             });
 
+            Assert.AreEqual (evs.Count, 6);
             AssertList (groupedView, dt, new[] { entry3, entry1 }, entry2);
 
             // Events after first push
@@ -741,7 +750,9 @@ namespace Toggl.Phoebe.Tests.Data
 
             var evs = await GetEvents (2, groupedView, feed, () => feed.Push (entry3, DataAction.Put));
 
+            Assert.AreEqual (evs.Count, 2);
             AssertList (groupedView, dt, new[] { entry3, entry2 }, entry1);
+
             AssertEvent (evs[0], "replace", "date header");
             AssertEvent (evs[1], "replace", "time entry");
         }
@@ -769,7 +780,9 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (entry3, DataAction.Delete);
             });
 
+            Assert.AreEqual (evs.Count, 3);
             AssertList (groupedView, dt, entry1);
+
             AssertEvent (evs[0], "replace", "date header");
             AssertEvent (evs[1], "remove", "time entry");
             AssertEvent (evs[2], "replace", "time entry");
@@ -797,7 +810,9 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (CreateTimeEntry (entry3, proj: proj2), DataAction.Put);
             });
 
+            Assert.AreEqual (evs.Count, 1);
             AssertList (groupedView, dt, new[] { entry1, entry2, entry3 });
+
             AssertEvent (evs[0], "replace", "time entry");
         }
 
@@ -817,11 +832,12 @@ namespace Toggl.Phoebe.Tests.Data
             AssertList (groupedView, dt, new[] { entry1, entry2, entry3 });
 
             // Edit project for all entries in group
-            var evs = await GetEvents (2, groupedView, feed, () =>
-                                       feed.Push (CreateTimeEntry (entry1, proj: proj2), DataAction.Put)
-                                      );
+            var evs = await GetEvents (
+                          2, groupedView, feed, () => feed.Push (CreateTimeEntry (entry1, proj: proj2), DataAction.Put));
 
+            Assert.AreEqual (evs.Count, 2);
             AssertList (groupedView, dt, entry1, new[] { entry2, entry3 });
+
             AssertEvent (evs[0], "add", "time entry");
             AssertEvent (evs[1], "replace", "time entry");
         }

--- a/Tests/Data/TimeEntriesCollectionTest.cs
+++ b/Tests/Data/TimeEntriesCollectionTest.cs
@@ -268,7 +268,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (entry2, DataAction.Put);
             });
 
-            Assert.AreEqual (evs.Count, 4);
+            Assert.AreEqual (4, evs.Count);
             AssertList (singleView, dt, entry2, entry1);
 
             // Events after first push
@@ -302,7 +302,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (entries[4], DataAction.Delete);  // Delete entry
             });
 
-            Assert.AreEqual (evs.Count, 4);
+            Assert.AreEqual (4, evs.Count);
             AssertList (singleView, dt, entries[0], dt.AddDays (-1), entries[3], entries[1]);
 
             AssertEvent (evs[0], "replace", "date header"); // Update today's header
@@ -333,7 +333,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (entries[1], DataAction.Delete); // Delete entry
             });
 
-            Assert.AreEqual (evs.Count, 5);
+            Assert.AreEqual (5, evs.Count);
             AssertList (singleView, dt.AddDays (1), entries[3], dt, entries[2], entries[4]);
 
             AssertEvent (evs[0], "replace", "date header"); // Update today's header
@@ -363,7 +363,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (entry5, DataAction.Put); // Add entry
             });
 
-            Assert.AreEqual (evs.Count, 4);
+            Assert.AreEqual (4, evs.Count);
             AssertList (singleView, dt, entry1, entry3, dt.AddDays (-1), entry4, entry2, entry5);
 
             AssertEvent (evs[0], "add", "time entry");
@@ -392,7 +392,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (CreateTimeEntry (entry4, 1), DataAction.Put); // Move entry to next day
             });
 
-            Assert.AreEqual (evs.Count, 5);
+            Assert.AreEqual (5, evs.Count);
             AssertList (singleView, dt.AddDays (1), entry1, entry4, entry2, dt, entry3, entry5);
 
             AssertEvent (evs[0], "add", "date header");
@@ -426,7 +426,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (CreateTimeEntry (entry2, daysOffset: -1), DataAction.Put);
             });
 
-            Assert.AreEqual (evs.Count, 6);
+            Assert.AreEqual (6, evs.Count);
             AssertList (singleView, dt, entry3, dt.AddDays (-1), entry2, entry5, entry4);
 
             AssertEvent (evs[0], "replace", "date header");
@@ -460,7 +460,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (CreateTimeEntry (entry5, daysOffset: 1), DataAction.Put);
             });
 
-            Assert.AreEqual (evs.Count, 7);
+            Assert.AreEqual (7, evs.Count);
             AssertList (singleView, dt, entry3, entry1, entry2, entry5, dt.AddDays (-1), entry6);
 
             AssertEvent (evs[0], "replace", "date header");
@@ -492,7 +492,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (entry4, DataAction.Delete);
             });
 
-            Assert.AreEqual (evs.Count, 6);
+            Assert.AreEqual (6, evs.Count);
             AssertList (singleView, dt, entry3, entry2, dt.AddDays (-1), entry1);
 
             AssertEvent (evs[0], "replace", "date header");
@@ -525,7 +525,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (CreateTimeEntry (entries[4], 0, 2), DataAction.Put);
             });
 
-            Assert.AreEqual (evs.Count, 3);
+            Assert.AreEqual (3, evs.Count);
             AssertList (singleView, dt, entries[0], entries[1], entries[2], entries[3], dt.AddDays (-1), entries[4]);
 
             // The date header doesn't change because total duration remains the same
@@ -555,7 +555,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (CreateTimeEntry (entry1, daysOffset: 1), DataAction.Put);
             });
 
-            Assert.AreEqual (evs.Count, 4);
+            Assert.AreEqual (4, evs.Count);
             AssertList (singleView, dt.AddDays (1), entry1, entry2);
 
             AssertEvent (evs[0], "remove", "date header"); // Remove old header
@@ -584,7 +584,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (CreateTimeEntry (entry2, daysOffset: -1), DataAction.Put);
             });
 
-            Assert.AreEqual (evs.Count, 4);
+            Assert.AreEqual (4, evs.Count);
             AssertList (singleView, dt.AddDays (-1), entry1, entry2);
 
             AssertEvent (evs[0], "remove", "date header"); // Remove old header
@@ -611,7 +611,7 @@ namespace Toggl.Phoebe.Tests.Data
                                        // Move first entry to previous day
                                        feed.Push (CreateTimeEntry (entry1, daysOffset: -1), DataAction.Put));
 
-            Assert.AreEqual (evs.Count, 3);
+            Assert.AreEqual (3, evs.Count);
             AssertList (singleView, dt, entry2, dt.AddDays (-1), entry1, entry3);
 
             AssertEvent (evs[0], "replace", "date header");
@@ -638,7 +638,7 @@ namespace Toggl.Phoebe.Tests.Data
                                        // Move first entry to previous day
                                        feed.Push (CreateTimeEntry (entry1, daysOffset: -1), DataAction.Put));
 
-            Assert.AreEqual (evs.Count, 3);
+            Assert.AreEqual (3, evs.Count);
             AssertList (singleView, dt, entry2, entry3, entry4, dt.AddDays (-1), entry1);
 
             AssertEvent (evs[0], "replace", "date header"); // Update old header
@@ -665,7 +665,7 @@ namespace Toggl.Phoebe.Tests.Data
                                        // Move first entry to next day
                                        feed.Push (CreateTimeEntry (entry4, daysOffset: 1), DataAction.Put));
 
-            Assert.AreEqual (evs.Count, 3);
+            Assert.AreEqual (3, evs.Count);
             AssertList (singleView, dt.AddDays (1), entry4, dt, entry1, entry2, entry3);
 
             AssertEvent (evs[0], "add", "date header");     // Add new header
@@ -692,7 +692,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (CreateTimeEntry (entry3, minutesOffset: 10), DataAction.Put);
             });
 
-            Assert.AreEqual (evs.Count, 3);
+            Assert.AreEqual (3, evs.Count);
             AssertList (singleView, dt, entry3, entry1, entry2);
 
             AssertEvent (evs[0], "move", "time entry");    // Move time entry3
@@ -719,7 +719,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (entry3, DataAction.Put);
             });
 
-            Assert.AreEqual (evs.Count, 6);
+            Assert.AreEqual (6, evs.Count);
             AssertList (groupedView, dt, new[] { entry3, entry1 }, entry2);
 
             // Events after first push
@@ -750,7 +750,7 @@ namespace Toggl.Phoebe.Tests.Data
 
             var evs = await GetEvents (2, groupedView, feed, () => feed.Push (entry3, DataAction.Put));
 
-            Assert.AreEqual (evs.Count, 2);
+            Assert.AreEqual (2, evs.Count);
             AssertList (groupedView, dt, new[] { entry3, entry2 }, entry1);
 
             AssertEvent (evs[0], "replace", "date header");
@@ -780,7 +780,7 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (entry3, DataAction.Delete);
             });
 
-            Assert.AreEqual (evs.Count, 3);
+            Assert.AreEqual (3, evs.Count);
             AssertList (groupedView, dt, entry1);
 
             AssertEvent (evs[0], "replace", "date header");
@@ -792,28 +792,34 @@ namespace Toggl.Phoebe.Tests.Data
         public async void GroupTestEditProject ()
         {
             var dt = new DateTime (2015, 12, 14, 10, 0, 0, 0);
-            Guid task = Guid.NewGuid (), proj1 = Guid.NewGuid (), proj2 = Guid.NewGuid ();
+            Guid task = Guid.NewGuid (), proj1 = Guid.NewGuid (), proj2 = Guid.NewGuid (), proj3 = Guid.NewGuid ();
 
-            var entry1 = CreateTimeEntry (dt.AddMinutes (10), task, proj1);
-            var entry2 = CreateTimeEntry (dt.AddMinutes (5), task, proj1);
-            var entry3 = CreateTimeEntry (dt, task, proj1);
+            var entry1 = CreateTimeEntry (dt.AddMinutes (20), task, proj1);
+            var entry2 = CreateTimeEntry (dt.AddMinutes (15), task, proj1);
+            var entry3 = CreateTimeEntry (dt.AddMinutes (10), task, proj1);
+            var entry4 = CreateTimeEntry (dt.AddMinutes (5), task, proj2);
+            var entry5 = CreateTimeEntry (dt, task, proj2);
+
 
             var feed = new TestFeed ();
-            var groupedView = await CreateTimeEntriesCollection<TimeEntryGroup> (feed, 100, entry1, entry2, entry3);
+            var groupedView = await CreateTimeEntriesCollection<TimeEntryGroup> (feed, 100, entry1, entry2, entry3, entry4, entry5);
 
-            AssertList (groupedView, dt, new[] { entry1, entry2, entry3 });
+            AssertList (groupedView, dt, new[] { entry1, entry2, entry3 }, new[] { entry4, entry5 });
 
             // Edit project for all entries in group
-            var evs = await GetEvents (1, groupedView, feed, () => {
-                feed.Push (CreateTimeEntry (entry1, proj: proj2), DataAction.Put);
-                feed.Push (CreateTimeEntry (entry2, proj: proj2), DataAction.Put);
-                feed.Push (CreateTimeEntry (entry3, proj: proj2), DataAction.Put);
+            var evs = await GetEvents (2, groupedView, feed, () => {
+                feed.Push (CreateTimeEntry (entry1, proj: proj3), DataAction.Put);
+                feed.Push (CreateTimeEntry (entry2, proj: proj3), DataAction.Put);
+                feed.Push (CreateTimeEntry (entry3, proj: proj3), DataAction.Put);
             });
 
-            Assert.AreEqual (evs.Count, 1);
-            AssertList (groupedView, dt, new[] { entry1, entry2, entry3 });
+            Assert.AreEqual (2, evs.Count);
+            AssertList (groupedView, dt, new[] { entry1, entry2, entry3 }, new[] { entry4, entry5 });
 
-            AssertEvent (evs[0], "replace", "time entry");
+            AssertEvent (evs[0], "remove", "time entry");
+            AssertEvent (evs[1], "add", "time entry");
+            Assert.AreEqual (proj3, ((TimeEntryGroup)groupedView[1]).Data.ProjectId);
+            Assert.AreEqual (proj2, ((TimeEntryGroup)groupedView[2]).Data.ProjectId);
         }
 
         [Test]
@@ -827,19 +833,68 @@ namespace Toggl.Phoebe.Tests.Data
             var entry3 = CreateTimeEntry (dt, task, proj1);
 
             var feed = new TestFeed ();
-            var groupedView = await CreateTimeEntriesCollection<TimeEntryGroup> (feed, 100, entry1, entry2, entry3);
+            var groupedView = await CreateTimeEntriesCollection<TimeEntryGroup> (feed, 0, entry1, entry2, entry3);
 
             AssertList (groupedView, dt, new[] { entry1, entry2, entry3 });
 
-            // Edit project for all entries in group
             var evs = await GetEvents (
                           2, groupedView, feed, () => feed.Push (CreateTimeEntry (entry1, proj: proj2), DataAction.Put));
 
-            Assert.AreEqual (evs.Count, 2);
+            Assert.AreEqual (2, evs.Count);
             AssertList (groupedView, dt, entry1, new[] { entry2, entry3 });
 
             AssertEvent (evs[0], "add", "time entry");
             AssertEvent (evs[1], "replace", "time entry");
+        }
+
+        [Test]
+        public async void GroupTestJoin ()
+        {
+            var dt = new DateTime (2015, 12, 14, 10, 0, 0, 0);
+            Guid task = Guid.NewGuid (), proj1 = Guid.NewGuid (), proj2 = Guid.NewGuid ();
+
+            var entry1 = CreateTimeEntry (dt.AddMinutes (10), task, proj1);
+            var entry2 = CreateTimeEntry (dt, task, proj2);
+
+            var feed = new TestFeed ();
+            var groupedView = await CreateTimeEntriesCollection<TimeEntryGroup> (feed, 0, entry1, entry2);
+
+            AssertList (groupedView, dt, entry1, entry2);
+
+            var evs = await GetEvents (
+                          2, groupedView, feed, () => feed.Push (CreateTimeEntry (entry1, proj: proj2), DataAction.Put));
+
+            Assert.AreEqual (2, evs.Count);
+            AssertList (groupedView, dt, new[] { entry1, entry2 });
+
+            AssertEvent (evs[0], "remove", "time entry");
+            AssertEvent (evs[1], "replace", "time entry");
+        }
+
+        [Test]
+        public async void GroupTestRestartBottomGroup ()
+        {
+            var dt = new DateTime (2015, 12, 14, 10, 0, 0, 0);
+            Guid task = Guid.NewGuid (), proj1 = Guid.NewGuid (), proj2 = Guid.NewGuid ();
+
+            var entry1 = CreateTimeEntry (dt.AddMinutes (10), task, proj2);
+            var entry2 = CreateTimeEntry (dt.AddMinutes (5), task, proj1);
+            var entry3 = CreateTimeEntry (dt, task, proj2);
+
+            var feed = new TestFeed ();
+            var groupedView = await CreateTimeEntriesCollection<TimeEntryGroup> (feed, 0, entry2, entry3);
+
+            AssertList (groupedView, dt, entry2, entry3);
+
+            entry1.State = TimeEntryState.Running;
+            var evs = await GetEvents (2, groupedView, feed, () => feed.Push (entry1, DataAction.Put));
+
+            Assert.AreEqual (2, evs.Count);
+            AssertList (groupedView, dt, new[] { entry1, entry3 }, entry2);
+
+            AssertEvent (evs[0], "replace", "date header");
+            AssertEvent (evs[1], "move", "time entry");
+            Assert.AreEqual (TimeEntryState.Running, ((ITimeEntryHolder)evs [1].Item).Data.State);
         }
     }
 }

--- a/Tests/Data/TimeEntriesCollectionTest.cs
+++ b/Tests/Data/TimeEntriesCollectionTest.cs
@@ -296,19 +296,20 @@ namespace Toggl.Phoebe.Tests.Data
             var feed = new TestFeed ();
             var singleView = await CreateTimeEntriesCollection<TimeEntryHolder> (feed, 100, entries);
 
-            var evs = await GetEvents (4, singleView, feed, () => {
+            var evs = await GetEvents (5, singleView, feed, () => {
                 feed.Push (CreateTimeEntry (entries[1], -1), DataAction.Put); // Move entry to previous day
                 feed.Push (entries[2], DataAction.Delete);  // Delete entry
                 feed.Push (entries[4], DataAction.Delete);  // Delete entry
             });
 
-            Assert.AreEqual (4, evs.Count);
+            Assert.AreEqual (5, evs.Count);
             AssertList (singleView, dt, entries[0], dt.AddDays (-1), entries[3], entries[1]);
 
             AssertEvent (evs[0], "replace", "date header"); // Update today's header
             AssertEvent (evs[1], "remove", "time entry");   // Remove time entry
             AssertEvent (evs[2], "remove", "time entry");   // Remove time entry
             AssertEvent (evs[3], "move", "time entry");     // Move time entry
+            AssertEvent (evs[4], "replace", "time entry");
         }
 
         [Test]
@@ -327,20 +328,21 @@ namespace Toggl.Phoebe.Tests.Data
             var feed = new TestFeed ();
             var singleView = await CreateTimeEntriesCollection<TimeEntryHolder> (feed, 100, entries);
 
-            var evs = await GetEvents (5, singleView, feed, () => {
+            var evs = await GetEvents (6, singleView, feed, () => {
                 feed.Push (CreateTimeEntry (entries[3], 1), DataAction.Put); // Move entry to next day
                 feed.Push (entries[0], DataAction.Delete); // Delete entry
                 feed.Push (entries[1], DataAction.Delete); // Delete entry
             });
 
-            Assert.AreEqual (5, evs.Count);
+            Assert.AreEqual (6, evs.Count);
             AssertList (singleView, dt.AddDays (1), entries[3], dt, entries[2], entries[4]);
 
             AssertEvent (evs[0], "replace", "date header"); // Update today's header
             AssertEvent (evs[1], "remove", "time entry");   // Remove time entry
             AssertEvent (evs[2], "remove", "time entry");     // Move time entry
             AssertEvent (evs[3], "move", "time entry");     // Move time entry
-            AssertEvent (evs[4], "replace", "date header"); // Update yesterday's header
+            AssertEvent (evs[4], "replace", "time entry");
+            AssertEvent (evs[5], "replace", "date header"); // Update yesterday's header
         }
 
         [Test]
@@ -357,19 +359,20 @@ namespace Toggl.Phoebe.Tests.Data
             var feed = new TestFeed ();
             var singleView = await CreateTimeEntriesCollection<TimeEntryHolder> (feed, 100, entry1, entry2, entry4);
 
-            var evs = await GetEvents (4, singleView, feed, () => {
+            var evs = await GetEvents (5, singleView, feed, () => {
                 feed.Push (CreateTimeEntry (entry2, -1), DataAction.Put); // Move entry to previous day
                 feed.Push (entry3, DataAction.Put); // Add entry
                 feed.Push (entry5, DataAction.Put); // Add entry
             });
 
-            Assert.AreEqual (4, evs.Count);
+            Assert.AreEqual (5, evs.Count);
             AssertList (singleView, dt, entry1, entry3, dt.AddDays (-1), entry4, entry2, entry5);
 
             AssertEvent (evs[0], "add", "time entry");
             AssertEvent (evs[1], "replace", "date header");
             AssertEvent (evs[2], "move", "time entry");
-            AssertEvent (evs[3], "add", "time entry");
+            AssertEvent (evs[3], "replace", "time entry");
+            AssertEvent (evs[4], "add", "time entry");
         }
 
         [Test]
@@ -386,20 +389,21 @@ namespace Toggl.Phoebe.Tests.Data
             var feed = new TestFeed ();
             var singleView = await CreateTimeEntriesCollection<TimeEntryHolder> (feed, 100, entry3, entry4, entry5);
 
-            var evs = await GetEvents (5, singleView, feed, () => {
+            var evs = await GetEvents (6, singleView, feed, () => {
                 feed.Push (entry2, DataAction.Put); // Add entry
                 feed.Push (entry1, DataAction.Put); // Add entry
                 feed.Push (CreateTimeEntry (entry4, 1), DataAction.Put); // Move entry to next day
             });
 
-            Assert.AreEqual (5, evs.Count);
+            Assert.AreEqual (6, evs.Count);
             AssertList (singleView, dt.AddDays (1), entry1, entry4, entry2, dt, entry3, entry5);
 
             AssertEvent (evs[0], "add", "date header");
             AssertEvent (evs[1], "add", "time entry");
             AssertEvent (evs[2], "move", "time entry");
-            AssertEvent (evs[3], "add", "time entry");
-            AssertEvent (evs[4], "replace", "date header");
+            AssertEvent (evs[3], "replace", "time entry");
+            AssertEvent (evs[4], "add", "time entry");
+            AssertEvent (evs[5], "replace", "date header");
         }
 
         [Test]
@@ -418,7 +422,7 @@ namespace Toggl.Phoebe.Tests.Data
             var singleView = await CreateTimeEntriesCollection<TimeEntryHolder> (
                                  feed, 100, entry1, entry2, entry4, entry5, entry6);
 
-            var evs = await GetEvents (6, singleView, feed, () => {
+            var evs = await GetEvents (8, singleView, feed, () => {
                 feed.Push (entry1, DataAction.Delete);
                 feed.Push (entry3, DataAction.Put);
                 feed.Push (entry6, DataAction.Delete);
@@ -426,15 +430,17 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (CreateTimeEntry (entry2, daysOffset: -1), DataAction.Put);
             });
 
-            Assert.AreEqual (6, evs.Count);
+            Assert.AreEqual (8, evs.Count);
             AssertList (singleView, dt, entry3, dt.AddDays (-1), entry2, entry5, entry4);
 
             AssertEvent (evs[0], "replace", "date header");
             AssertEvent (evs[1], "remove", "time entry");
             AssertEvent (evs[2], "add", "time entry");
             AssertEvent (evs[3], "move", "time entry");
-            AssertEvent (evs[4], "remove", "time entry");
-            AssertEvent (evs[5], "move", "time entry");
+            AssertEvent (evs[4], "replace", "time entry");
+            AssertEvent (evs[5], "remove", "time entry");
+            AssertEvent (evs[6], "move", "time entry");
+            AssertEvent (evs[7], "replace", "time entry");
         }
 
         [Test]
@@ -452,7 +458,7 @@ namespace Toggl.Phoebe.Tests.Data
             var feed = new TestFeed ();
             var singleView = await CreateTimeEntriesCollection<TimeEntryHolder> (feed, 100, entry1, entry3, entry4, entry5);
 
-            var evs = await GetEvents (7, singleView, feed, () => {
+            var evs = await GetEvents (9, singleView, feed, () => {
                 feed.Push (entry4, DataAction.Delete);
                 feed.Push (entry2, DataAction.Put);
                 feed.Push (entry6, DataAction.Put);
@@ -460,16 +466,18 @@ namespace Toggl.Phoebe.Tests.Data
                 feed.Push (CreateTimeEntry (entry5, daysOffset: 1), DataAction.Put);
             });
 
-            Assert.AreEqual (7, evs.Count);
+            Assert.AreEqual (9, evs.Count);
             AssertList (singleView, dt, entry3, entry1, entry2, entry5, dt.AddDays (-1), entry6);
 
             AssertEvent (evs[0], "replace", "date header");
             AssertEvent (evs[1], "move", "time entry");
-            AssertEvent (evs[2], "add", "time entry");
-            AssertEvent (evs[3], "move", "time entry");
-            AssertEvent (evs[4], "replace", "date header");
-            AssertEvent (evs[5], "remove", "time entry");
-            AssertEvent (evs[6], "add", "time entry");
+            AssertEvent (evs[2], "replace", "time entry");
+            AssertEvent (evs[3], "add", "time entry");
+            AssertEvent (evs[4], "move", "time entry");
+            AssertEvent (evs[5], "replace", "time entry");
+            AssertEvent (evs[6], "replace", "date header");
+            AssertEvent (evs[7], "remove", "time entry");
+            AssertEvent (evs[8], "add", "time entry");
         }
 
         [Test]
@@ -485,22 +493,24 @@ namespace Toggl.Phoebe.Tests.Data
             var feed = new TestFeed ();
             var singleView = await CreateTimeEntriesCollection<TimeEntryHolder> (feed, 100, entry1, entry3, entry4);
 
-            var evs = await GetEvents (6, singleView, feed, () => {
+            var evs = await GetEvents (8, singleView, feed, () => {
                 feed.Push (CreateTimeEntry (entry3, 1, -10), DataAction.Put);
                 feed.Push (CreateTimeEntry (entry1, -1, -20), DataAction.Put);
                 feed.Push (entry2, DataAction.Put);
                 feed.Push (entry4, DataAction.Delete);
             });
 
-            Assert.AreEqual (6, evs.Count);
+            Assert.AreEqual (8, evs.Count);
             AssertList (singleView, dt, entry3, entry2, dt.AddDays (-1), entry1);
 
             AssertEvent (evs[0], "replace", "date header");
             AssertEvent (evs[1], "move", "time entry");
-            AssertEvent (evs[2], "add", "time entry");
-            AssertEvent (evs[3], "replace", "date header");
-            AssertEvent (evs[4], "remove", "time entry");
-            AssertEvent (evs[5], "move", "time entry");
+            AssertEvent (evs[2], "replace", "time entry");
+            AssertEvent (evs[3], "add", "time entry");
+            AssertEvent (evs[4], "replace", "date header");
+            AssertEvent (evs[5], "remove", "time entry");
+            AssertEvent (evs[6], "move", "time entry");
+            AssertEvent (evs[7], "replace", "time entry");
         }
 
         [Test]
@@ -607,16 +617,17 @@ namespace Toggl.Phoebe.Tests.Data
             // Order check before update
             AssertList (singleView, dt, entry1, entry2, dt.AddDays (-1), entry3);
 
-            var evs = await GetEvents (3, singleView, feed, () =>
+            var evs = await GetEvents (4, singleView, feed, () =>
                                        // Move first entry to previous day
                                        feed.Push (CreateTimeEntry (entry1, daysOffset: -1), DataAction.Put));
 
-            Assert.AreEqual (3, evs.Count);
+            Assert.AreEqual (4, evs.Count);
             AssertList (singleView, dt, entry2, dt.AddDays (-1), entry1, entry3);
 
             AssertEvent (evs[0], "replace", "date header");
             AssertEvent (evs[1], "replace", "date header");
             AssertEvent (evs[2], "move", "time entry");
+            AssertEvent (evs[3], "replace", "time entry");
         }
 
         [Test]
@@ -634,16 +645,17 @@ namespace Toggl.Phoebe.Tests.Data
             // Order check before update
             AssertList (singleView, dt, entry1, entry2, entry3, entry4);
 
-            var evs = await GetEvents (3, singleView, feed, () =>
+            var evs = await GetEvents (4, singleView, feed, () =>
                                        // Move first entry to previous day
                                        feed.Push (CreateTimeEntry (entry1, daysOffset: -1), DataAction.Put));
 
-            Assert.AreEqual (3, evs.Count);
+            Assert.AreEqual (4, evs.Count);
             AssertList (singleView, dt, entry2, entry3, entry4, dt.AddDays (-1), entry1);
 
             AssertEvent (evs[0], "replace", "date header"); // Update old header
             AssertEvent (evs[1], "add", "date header");     // Add new header
             AssertEvent (evs[2], "move", "time entry");     // Move time entry
+            AssertEvent (evs[3], "replace", "time entry");
         }
 
         [Test]
@@ -661,16 +673,17 @@ namespace Toggl.Phoebe.Tests.Data
             // Order check before update
             AssertList (singleView, dt, entry1, entry2, entry3, entry4);
 
-            var evs = await GetEvents (3, singleView, feed, () =>
+            var evs = await GetEvents (4, singleView, feed, () =>
                                        // Move first entry to next day
                                        feed.Push (CreateTimeEntry (entry4, daysOffset: 1), DataAction.Put));
 
-            Assert.AreEqual (3, evs.Count);
+            Assert.AreEqual (4, evs.Count);
             AssertList (singleView, dt.AddDays (1), entry4, dt, entry1, entry2, entry3);
 
             AssertEvent (evs[0], "add", "date header");     // Add new header
             AssertEvent (evs[1], "move", "time entry");     // Move time entry
-            AssertEvent (evs[2], "replace", "date header"); // Update old header
+            AssertEvent (evs[2], "replace", "time entry");
+            AssertEvent (evs[3], "replace", "date header"); // Update old header
         }
 
         [Test]
@@ -685,19 +698,21 @@ namespace Toggl.Phoebe.Tests.Data
             var feed = new TestFeed ();
             var singleView = await CreateTimeEntriesCollection<TimeEntryHolder> (feed, 100, entry1, entry2, entry3);
 
-            var evs = await GetEvents (3, singleView, feed, () => {
+            var evs = await GetEvents (4, singleView, feed, () => {
                 // Shuffle time entries
                 feed.Push (CreateTimeEntry (entry1, minutesOffset: -5), DataAction.Put);
                 feed.Push (CreateTimeEntry (entry2, minutesOffset: -5), DataAction.Put);
                 feed.Push (CreateTimeEntry (entry3, minutesOffset: 10), DataAction.Put);
             });
 
-            Assert.AreEqual (3, evs.Count);
+            Assert.AreEqual (4, evs.Count);
             AssertList (singleView, dt, entry3, entry1, entry2);
 
             AssertEvent (evs[0], "move", "time entry");    // Move time entry3
-            AssertEvent (evs[1], "replace", "time entry"); // Update time entry1
-            AssertEvent (evs[2], "replace", "time entry"); // Update time entry2
+            AssertEvent (evs[1], "replace", "time entry");
+
+            AssertEvent (evs[2], "replace", "time entry"); // Update time entry1
+            AssertEvent (evs[3], "replace", "time entry"); // Update time entry2
         }
 
         [Test]
@@ -713,13 +728,13 @@ namespace Toggl.Phoebe.Tests.Data
             var entry2 = CreateTimeEntry (dt.AddHours (1), task2, prj);
             var entry3 = CreateTimeEntry (dt.AddHours (2), task1, prj);
 
-            var evs = await GetEvents (6, groupedView, feed, () => {
+            var evs = await GetEvents (7, groupedView, feed, () => {
                 feed.Push (entry1, DataAction.Put);
                 feed.Push (entry2, DataAction.Put);
                 feed.Push (entry3, DataAction.Put);
             });
 
-            Assert.AreEqual (6, evs.Count);
+            Assert.AreEqual (7, evs.Count);
             AssertList (groupedView, dt, new[] { entry3, entry1 }, entry2);
 
             // Events after first push
@@ -733,6 +748,7 @@ namespace Toggl.Phoebe.Tests.Data
             // Events after third push
             AssertEvent (evs[4], "replace", "date header");
             AssertEvent (evs[5], "move", "time entry");
+            AssertEvent (evs[6], "replace", "time entry");
         }
 
         [Test]
@@ -887,13 +903,14 @@ namespace Toggl.Phoebe.Tests.Data
             AssertList (groupedView, dt, entry2, entry3);
 
             entry1.State = TimeEntryState.Running;
-            var evs = await GetEvents (2, groupedView, feed, () => feed.Push (entry1, DataAction.Put));
+            var evs = await GetEvents (3, groupedView, feed, () => feed.Push (entry1, DataAction.Put));
 
-            Assert.AreEqual (2, evs.Count);
+            Assert.AreEqual (3, evs.Count);
             AssertList (groupedView, dt, new[] { entry1, entry3 }, entry2);
 
             AssertEvent (evs[0], "replace", "date header");
             AssertEvent (evs[1], "move", "time entry");
+            AssertEvent (evs[2], "replace", "time entry");
             Assert.AreEqual (TimeEntryState.Running, ((ITimeEntryHolder)evs [1].Item).Data.State);
         }
     }


### PR DESCRIPTION
Main changes:
- Now every time the time entry collection is updated **the entries are ungrouped and grouped again**. This may affect performance a bit but it shouldn't be noticed by the users as updates only happen every 500 ms at most. Also, it gives us more flexibility if we want to add new ways of grouping entries.  
  The previous (more imperative) way of updating grouped list wasn't working well in cases, for example, when the user edited entries in the web separately, as the same message from the server could make an entry be remove from one group and added in another.
- **After every Move event, a Replace event is also triggered** (see `ObservableRangeCollection.Move`) to force the view to update the moved item (this wasn't always happening with simple Move events).
- Adds unit test for grouped entries (see `TimeEntriesCollectionTest`)

Closes #1144