### PR TITLE
Don't use a static cache for Diff

### DIFF
--- a/Phoebe/Data/Diff.cs
+++ b/Phoebe/Data/Diff.cs
@@ -91,18 +91,17 @@ namespace Toggl.Phoebe.Data
         readonly IDictionary<int, DiffComparison> Cache = new Dictionary<int, DiffComparison> ();
 
         public DiffComparison Compare<T> (IList<T> listA, int indexA, IList<T> listB, int indexB)
-            where T : IDiffComparable
+        where T : IDiffComparable
         {
             var key = indexA | (indexB << 16);
             if (Cache.ContainsKey (key)) {
                 return Cache [key];
-            }
-            else {
+            } else {
                 var res = listA [indexA].Compare (listB [indexB]);
                 Cache.Add (key, res);
                 return res;
             }
-        }        
+        }
     }
 
     // Adapted from http://devdirective.com/post/115/creating-a-reusable-though-simple-diff-implementation-in-csharp-part-3


### PR DESCRIPTION
Fixes #1156.
Not sure why the problem (Duplicated keys being added to Diff cache) was happening. It looks like a race condition, but this shouldn’t happen thanks to Rx scheduler. In any case, having the cache as a static property was not a good decision, so I’ve fixed that. Let’s monitor the problem in Raygun to be sure it gets solved.
Note: I also thought to use a `ConcurrentDictionary` but this is probably overkill and would affect performance. It shouldn’t have any effect anyway as the `Diff.Calculate` method is synchronous an now is creating a new cache for every call.