### PR TITLE
Wait until ActiveTimeEntryManager has initialised

### DIFF
--- a/Tests/Data/ActiveTimeEntryManagerTest.cs
+++ b/Tests/Data/ActiveTimeEntryManagerTest.cs
@@ -35,10 +35,12 @@ namespace Toggl.Phoebe.Tests.Data
                 });
 
                 await SetUpFakeUser (user.Id);
+                var activeManager = new ActiveTimeEntryManager ();
+                await Util.AwaitPredicate (() => activeManager.ActiveTimeEntry != null);
 
                 ServiceContainer.Register<ExperimentManager> (new ExperimentManager ());
                 ServiceContainer.Register<ISyncManager> (Mock.Of<ISyncManager> (mgr => !mgr.IsRunning));
-                ServiceContainer.Register<ActiveTimeEntryManager> (new ActiveTimeEntryManager ());
+                ServiceContainer.Register<ActiveTimeEntryManager> (activeManager);
                 ServiceContainer.Register<ITracker> (() => new FakeTracker ());
             });
         }


### PR DESCRIPTION
In `ActiveTimeEntryManagerTest.Setup` wait until `ActiveTimeEntryManager.ActiveTimeEntry` has been initialised.
Fixes #1175 