### PR TITLE
Save description after editing.

### DIFF
--- a/Joey/UI/Fragments/EditTimeEntryFragment.cs
+++ b/Joey/UI/Fragments/EditTimeEntryFragment.cs
@@ -129,7 +129,11 @@ namespace Toggl.Joey.UI.Fragments
             // the event "CheckedChange" isn't found when
             // the app is compiled for release. Investigate!
             BillableCheckBox.CheckedChange += (sender, e) => {
-                ViewModel.IsBillable = BillableCheckBox.Checked;
+                ViewModel.ChangeBillable (BillableCheckBox.Checked);
+            };
+
+            DescriptionField.TextField.TextChanged += (sender, e) => {
+                ViewModel.ChangeDescription (DescriptionField.TextField.Text);
             };
 
             DurationTextView.Click += (sender, e) => {
@@ -169,7 +173,7 @@ namespace Toggl.Joey.UI.Fragments
             clientBinding = this.SetBinding (() => ViewModel.ClientName, () => ProjectField.AssistViewTitle);
             tagBinding = this.SetBinding (() => ViewModel.TagList, () => TagsField.TagNames)
                          .ConvertSourceToTarget (tagList => tagList.Select (tag => tag.Name).ToList ());
-            descriptionBinding = this.SetBinding (() => ViewModel.Description, () => DescriptionField.TextField.Text, BindingMode.TwoWay);
+            descriptionBinding = this.SetBinding (() => ViewModel.Description, () => DescriptionField.TextField.Text);
             isPremiumBinding = this.SetBinding (() => ViewModel.IsPremium, () => BillableCheckBox.Visibility)
                                .ConvertSourceToTarget (isVisible => isVisible ? ViewStates.Visible : ViewStates.Gone);
             isRunningBinding = this.SetBinding (() => ViewModel.IsRunning).WhenSourceChanges (() => {

--- a/Phoebe/Data/ViewModels/EditTimeEntryViewModel.cs
+++ b/Phoebe/Data/ViewModels/EditTimeEntryViewModel.cs
@@ -100,17 +100,7 @@ namespace Toggl.Phoebe.Data.ViewModels
 
         public string ClientName { get; private set; }
 
-        private string description;
-
-        public string Description
-        {
-            get {
-                return description;
-            } set {
-                description = value;
-                Task.Run (async () => await SaveAsync ()); // otherwise this can get overwritten
-            }
-        }
+        public string Description { get; private set; }
 
         public List<TagData> TagList { get; private set; }
 
@@ -178,6 +168,16 @@ namespace Toggl.Phoebe.Data.ViewModels
             RaisePropertyChanged (() => TagList);
         }
 
+        public void ChangeDescription (string description)
+        {
+            data.Description = description;
+        }
+
+        public void ChangeBillable (bool billable)
+        {
+            data.IsBillable = IsBillable = billable;
+        }
+
         public void AddTag (TagData tagData)
         {
             TagList.Add (tagData);
@@ -189,9 +189,6 @@ namespace Toggl.Phoebe.Data.ViewModels
             if (IsManual) {
                 return;
             }
-
-            data.IsBillable = IsBillable;
-            data.Description = Description;
 
             if (!data.PublicInstancePropertiesEqual (initialState)) {
                 data = await TimeEntryModel.PrepareForSync (data);

--- a/Phoebe/Data/ViewModels/EditTimeEntryViewModel.cs
+++ b/Phoebe/Data/ViewModels/EditTimeEntryViewModel.cs
@@ -100,7 +100,17 @@ namespace Toggl.Phoebe.Data.ViewModels
 
         public string ClientName { get; private set; }
 
-        public string Description { get; set; }
+        private string description;
+
+        public string Description
+        {
+            get {
+                return description;
+            } set {
+                description = value;
+                Task.Run (async () => await SaveAsync ()); // otherwise this can get overwritten
+            }
+        }
 
         public List<TagData> TagList { get; private set; }
 


### PR DESCRIPTION
When you edit description, and then start to edit Start or stop time, the Description field in EditTimeEntryViewModel gets overwritten in https://github.com/toggl/mobile/blob/master/Phoebe/Data/ViewModels/EditTimeEntryViewModel.cs#L139
(temporary solution is to save the Description at the moment of editing (like all other fields).
Is there a cleaner way?

Closes https://github.com/toggl/mobile/issues/1220