### PR TITLE
Add native constructors to Android views - Fix #1369

### DIFF
--- a/Joey/UI/Activities/BaseActivity.cs
+++ b/Joey/UI/Activities/BaseActivity.cs
@@ -29,6 +29,16 @@ namespace Toggl.Joey.UI.Activities
         /// </summary>
         public static BaseActivity CurrentActivity { get; private set; }
 
+        // Explanation of native constructor
+        // http://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview/10603714#10603714
+        protected BaseActivity (IntPtr a, Android.Runtime.JniHandleOwnership b) : base (a, b)
+        {
+        }
+
+        protected BaseActivity ()
+        {
+        }
+
         private void OnSyncStarted (SyncStartedMessage msg)
         {
             if (Handle == IntPtr.Zero) {

--- a/Joey/UI/Activities/EditTimeEntryActivity.cs
+++ b/Joey/UI/Activities/EditTimeEntryActivity.cs
@@ -22,6 +22,16 @@ namespace Toggl.Joey.UI.Activities
         public static readonly string ExtraTimeEntryId = "com.toggl.timer.time_entry_id";
         public static readonly string ExtraGroupedTimeEntriesGuids = "com.toggl.timer.grouped_time_entry_id";
 
+        // Explanation of native constructor
+        // http://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview/10603714#10603714
+        public EditTimeEntryActivity (System.IntPtr a, Android.Runtime.JniHandleOwnership b) : base (a, b)
+        {
+        }
+
+        public EditTimeEntryActivity ()
+        {
+        }
+
         protected override void OnCreateActivity (Bundle state)
         {
             base.OnCreateActivity (state);

--- a/Joey/UI/Activities/LoginActivity.cs
+++ b/Joey/UI/Activities/LoginActivity.cs
@@ -61,6 +61,16 @@ namespace Toggl.Joey.UI.Activities
 
         protected Button GoogleLoginButton { get; private set; }
 
+        // Explanation of native constructor
+        // http://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview/10603714#10603714
+        public LoginActivity (IntPtr a, Android.Runtime.JniHandleOwnership b) : base (a, b)
+        {
+        }
+
+		public LoginActivity ()
+		{
+		}
+
         private void FindViews ()
         {
             ScrollView = FindViewById<ScrollView> (Resource.Id.ScrollView);

--- a/Joey/UI/Activities/MainDrawerActivity.cs
+++ b/Joey/UI/Activities/MainDrawerActivity.cs
@@ -67,6 +67,16 @@ namespace Toggl.Joey.UI.Activities
         public Toolbar MainToolbar { get; set; }
 
 
+        // Explanation of native constructor
+        // http://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview/10603714#10603714
+        public MainDrawerActivity (IntPtr a, Android.Runtime.JniHandleOwnership b) : base (a, b)
+        {
+        }
+
+        public MainDrawerActivity ()
+        {
+        }
+
         protected override void OnCreateActivity (Bundle state)
         {
             base.OnCreateActivity (state);

--- a/Joey/UI/Activities/NewProjectActivity.cs
+++ b/Joey/UI/Activities/NewProjectActivity.cs
@@ -14,6 +14,16 @@ namespace Toggl.Joey.UI.Activities
     {
         public static readonly string WorkspaceIdArgument = "com.toggl.timer.workspace_id";
 
+        // Explanation of native constructor
+        // http://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview/10603714#10603714
+        public NewProjectActivity (System.IntPtr a, Android.Runtime.JniHandleOwnership b) : base (a, b)
+        {
+        }
+
+        public NewProjectActivity ()
+        {
+        }
+
         protected override void OnCreateActivity (Bundle state)
         {
             base.OnCreateActivity (state);

--- a/Joey/UI/Activities/ProjectListActivity.cs
+++ b/Joey/UI/Activities/ProjectListActivity.cs
@@ -15,6 +15,16 @@ namespace Toggl.Joey.UI.Activities
     {
         private static readonly string fragmentTag = "projectlist_fragment";
 
+        // Explanation of native constructor
+        // http://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview/10603714#10603714
+        public ProjectListActivity (System.IntPtr a, Android.Runtime.JniHandleOwnership b) : base (a, b)
+        {
+        }
+
+        public ProjectListActivity ()
+        {
+        }
+
         protected override void OnCreateActivity (Bundle state)
         {
             base.OnCreateActivity (state);

--- a/Joey/UI/Adapters/DrawerListAdapter.cs
+++ b/Joey/UI/Adapters/DrawerListAdapter.cs
@@ -20,6 +20,12 @@ namespace Toggl.Joey.UI.Adapters
         private List<DrawerItem> rowItems;
         private readonly AuthManager authManager;
 
+        // Explanation of native constructor
+        // http://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview/10603714#10603714
+        public DrawerListAdapter (IntPtr a, Android.Runtime.JniHandleOwnership b) : base (a, b)
+        {
+        }
+
         public DrawerListAdapter ()
         {
             rowItems = new List<DrawerItem> () {
@@ -118,6 +124,12 @@ namespace Toggl.Joey.UI.Adapters
             public ImageView IconImageView { get; private set; }
 
             public TextView TitleTextView { get; private set; }
+
+            // Explanation of native constructor
+            // http://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview/10603714#10603714
+            public DrawerItemViewHolder (IntPtr a, Android.Runtime.JniHandleOwnership b) : base (a, b)
+            {
+            }
 
             public DrawerItemViewHolder (View root) : base (root)
             {

--- a/Joey/UI/Adapters/ProjectListAdapter.cs
+++ b/Joey/UI/Adapters/ProjectListAdapter.cs
@@ -99,6 +99,12 @@ namespace Toggl.Joey.UI.Adapters
             private ProjectListAdapter adapter;
             private ProjectsCollection.SuperProjectData projectData;
 
+            // Explanation of native constructor
+            // http://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview/10603714#10603714
+            public ProjectItemHolder (IntPtr a, Android.Runtime.JniHandleOwnership b) : base (a, b)
+            {
+            }
+
             public ProjectItemHolder (ProjectListAdapter adapter, View root) : base (root)
             {
                 this.adapter = adapter;

--- a/Joey/UI/Fragments/LogTimeEntriesListFragment.cs
+++ b/Joey/UI/Fragments/LogTimeEntriesListFragment.cs
@@ -64,6 +64,16 @@ namespace Toggl.Joey.UI.Fragments
 
         #endregion
 
+        // Explanation of native constructor
+        // http://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview/10603714#10603714
+        public LogTimeEntriesListFragment (IntPtr a, Android.Runtime.JniHandleOwnership b) : base (a, b)
+        {
+        }
+
+        public LogTimeEntriesListFragment ()
+        {
+        }
+
         public override View OnCreateView (LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
         {
             var view = inflater.Inflate (Resource.Layout.LogTimeEntriesListFragment, container, false);

--- a/Joey/UI/Fragments/ReportsFragment.cs
+++ b/Joey/UI/Fragments/ReportsFragment.cs
@@ -357,6 +357,12 @@ namespace Toggl.Joey.UI.Fragments
             private int focus = -1;
             private Controller controller;
 
+            // Explanation of native constructor
+            // http://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview/10603714#10603714
+            public ReportProjectAdapter (IntPtr a, Android.Runtime.JniHandleOwnership b) : base (a, b)
+            {
+            }
+
             public ReportProjectAdapter (Controller controller, List<ReportProject> dataView)
             {
                 this.controller = controller;

--- a/Joey/UI/Fragments/ReportsPagerFragment.cs
+++ b/Joey/UI/Fragments/ReportsPagerFragment.cs
@@ -74,6 +74,12 @@ namespace Toggl.Joey.UI.Fragments
             get { return reportsControllerPool; }
         }
 
+        // Explanation of native constructor
+        // http://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview/10603714#10603714
+        public ReportsPagerFragment (IntPtr a, Android.Runtime.JniHandleOwnership b) : base (a, b)
+        {
+        }
+
         public override void OnCreate (Bundle savedInstanceState)
         {
             base.OnCreate (savedInstanceState);

--- a/Joey/UI/Utils/BindableViewHolder.cs
+++ b/Joey/UI/Utils/BindableViewHolder.cs
@@ -11,6 +11,12 @@ namespace Toggl.Joey.UI.Utils
 
         public T DataSource { get; private set; }
 
+        // Explanation of native constructor
+        // http://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview/10603714#10603714
+        protected BindableViewHolder (System.IntPtr a, Android.Runtime.JniHandleOwnership b) : base (a, b)
+        {
+        }
+
         public BindableViewHolder (View root)
         {
             this.root = root;

--- a/Joey/UI/Views/BarChart.cs
+++ b/Joey/UI/Views/BarChart.cs
@@ -38,6 +38,12 @@ namespace Toggl.Joey.UI.Views
         private PointF tapInitialPos;
         private bool isZooming;
 
+        // Explanation of native constructor
+        // http://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview/10603714#10603714
+        public BarChart (IntPtr a, Android.Runtime.JniHandleOwnership b) : base (a, b)
+        {
+        }
+
         public BarChart (Context context, IAttributeSet attrs) : base (context, attrs)
         {
             Initialize (context);

--- a/Joey/UI/Views/DividerItemDecoration.cs
+++ b/Joey/UI/Views/DividerItemDecoration.cs
@@ -17,6 +17,12 @@ namespace Toggl.Joey.UI.Views
         public const int HorizontalList = LinearLayoutManager.Horizontal;
         public const int VerticalList = LinearLayoutManager.Vertical;
 
+        // Explanation of native constructor
+        // http://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview/10603714#10603714
+        public DividerItemDecoration (IntPtr a, JniHandleOwnership b) : base (a, b)
+        {
+        }
+
         public DividerItemDecoration (Context context, int orientation)
         {
             var a = context.ObtainStyledAttributes (Attrs);

--- a/Joey/UI/Views/NotificationImageView.cs
+++ b/Joey/UI/Views/NotificationImageView.cs
@@ -56,6 +56,12 @@ namespace Toggl.Joey.UI.Views
             }
         }
 
+        // Explanation of native constructor
+        // http://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview/10603714#10603714
+        public NotificationImageView (System.IntPtr a, Android.Runtime.JniHandleOwnership b) : base (a, b)
+        {
+        }
+
         public NotificationImageView (Context context) : base (context)
         {
             ctx = context;

--- a/Joey/UI/Views/PieChart.cs
+++ b/Joey/UI/Views/PieChart.cs
@@ -421,6 +421,12 @@ namespace Toggl.Joey.UI.Views
             private float endAngle;
             private float radius;
 
+            // Explanation of native constructor
+            // http://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview/10603714#10603714
+            public SliceView (IntPtr a, Android.Runtime.JniHandleOwnership b) : base (a, b)
+            {
+            }
+
             public SliceView (Context context) : base (context)
             {
                 var dm = context.Resources.DisplayMetrics;

--- a/Joey/Widget/RemotesViewsFactory.cs
+++ b/Joey/Widget/RemotesViewsFactory.cs
@@ -35,6 +35,12 @@ namespace Toggl.Joey.Widget
             }
         }
 
+        // Explanation of native constructor
+        // http://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview/10603714#10603714
+        public RemotesViewsFactory (IntPtr a, Android.Runtime.JniHandleOwnership b) : base (a, b)
+        {
+        }
+
         public RemotesViewsFactory (Context ctx)
         {
             context = ctx;


### PR DESCRIPTION
Native constructors have been added for activities and fragments reporting errors in Raygun. When necessary, a explicit parameterless constructor has been added too.

There are still some similar errors in Raygun related to internal classes in Android, like this one:
https://app.raygun.io/crashreporting/gn9q04/errors/1155254727#7789786252
```
[NotSupportedException: Unable to activate instance of type Android.Animation.AnimatorEventDispatcher from native handle 0xbef8af2c (key_handle 0xf31aa2d).]

[MissingMethodException: No constructor found for Android.Animation.AnimatorEventDispatcher::.ctor(System.IntPtr, Android.Runtime.JniHandleOwnership)]
```

We cannot touch these classes, so this problem requires further investigation.