### PR TITLE
Double.TryParse bug. Fixed with InvariantCulture parameter.

### DIFF
--- a/Phoebe/Data/Json/Converters/ReportJsonConverter.cs
+++ b/Phoebe/Data/Json/Converters/ReportJsonConverter.cs
@@ -88,7 +88,7 @@ namespace Toggl.Phoebe.Data.Json.Converters
             // round decimal values
             if (!string.IsNullOrEmpty (s) && s.Contains (".")) {
                 double d;
-                double.TryParse (s, out d);
+                double.TryParse (s, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out d);
                 l = (long)Math.Round (d);
             } else {
                 long.TryParse (s, out l);


### PR DESCRIPTION
…double.TryParse as cultures can use comma for decimal seperator, like da-DK.

See the repository https://github.com/jespersh/test-toggle-float for an example bug.