### PR TITLE
Fix #1537

### DIFF
--- a/Joey/UI/Adapters/LogTimeEntriesAdapter.cs
+++ b/Joey/UI/Adapters/LogTimeEntriesAdapter.cs
@@ -547,7 +547,7 @@ namespace Toggl.Joey.UI.Adapters
                     timer.Start();
                 }
 
-                DurationTextView.Text = TimeEntryData.GetFormattedDuration(null, duration);
+                DurationTextView.Text = TimeEntryData.GetFormattedDuration(duration);
             }
 
             private void OnDurationElapsed(object sender, ElapsedEventArgs e)

--- a/Phoebe/Data/Models/TimeEntryData.cs
+++ b/Phoebe/Data/Models/TimeEntryData.cs
@@ -131,12 +131,7 @@ namespace Toggl.Phoebe.Data.Models
         public static string GetFormattedDuration(UserData user, TimeSpan duration)
         {
             string formattedString = duration.ToString(@"hh\:mm\:ss");
-            if (user == null)
-            {
-                return formattedString;
-            }
-
-            if (user.DurationFormat == DurationFormat.Classic)
+            if (user == null || user.DurationFormat == DurationFormat.Classic)
             {
                 if (duration.TotalMinutes < 1)
                 {
@@ -148,7 +143,10 @@ namespace Toggl.Phoebe.Data.Models
                 }
                 else
                 {
-                    formattedString = duration.ToString(@"hh\:mm\:ss");
+                    formattedString = string.Format("{0:00}:{1:00}:{2:00}",
+                                                    Math.Floor(duration.TotalHours),
+                                                    duration.Minutes,
+                                                    duration.Seconds);
                 }
             }
             else if (user.DurationFormat == DurationFormat.Decimal)

--- a/Phoebe/Data/Models/TimeEntryData.cs
+++ b/Phoebe/Data/Models/TimeEntryData.cs
@@ -128,7 +128,7 @@ namespace Toggl.Phoebe.Data.Models
             }
         }
 
-        public static string GetFormattedDuration(UserData user, TimeSpan duration)
+        public static string GetFormattedDuration(TimeSpan duration, UserData user = null)
         {
             string formattedString = duration.ToString(@"hh\:mm\:ss");
             if (user == null || user.DurationFormat == DurationFormat.Classic)

--- a/Phoebe/ViewModels/EditTimeEntryVM.cs
+++ b/Phoebe/ViewModels/EditTimeEntryVM.cs
@@ -82,9 +82,7 @@ namespace Toggl.Phoebe.ViewModels
         {
             get
             {
-                // TODO: check substring function for long times
-                return TimeSpan.FromSeconds(richData.Data.GetDuration().TotalSeconds)
-                       .ToString().Substring(0, 8);
+                return TimeEntryData.GetFormattedDuration(richData.Data.GetDuration());
             }
         }
 


### PR DESCRIPTION
- Use `TimeSpan.TotalHours` when displaying TE duration
- Use `DurationFormat.Classic` as default when no UserData is available
- Unify duration display between Timer and Edit Time Entry views

Please check if these points are acceptable, especially the third one.