### PR TITLE
made edit view date picker show before setting date, fixing #1591

### DIFF
--- a/Ross/ViewControllers/EditTimeEntryViewController.cs
+++ b/Ross/ViewControllers/EditTimeEntryViewController.cs
@@ -302,24 +302,25 @@ namespace Toggl.Ross.ViewControllers
         private void OnStartStopViewSelectedChanged(object sender, EventArgs e)
         {
             var currentValue = datePicker.Date.ToDateTime().ToUtc();
+            var animate = !datePicker.Hidden;
+            DatePickerHidden = startStopView.Selected == TimeKind.None;
             switch (startStopView.Selected)
             {
                 case TimeKind.Start:
                     datePicker.Mode = ViewModel.IsRunning ? UIDatePickerMode.Time : UIDatePickerMode.DateAndTime;
                     if (currentValue != ViewModel.StartDate)
                     {
-                        datePicker.SetDate(ViewModel.StartDate.ToNSDate(), !datePicker.Hidden);
+                        datePicker.SetDate(ViewModel.StartDate.ToNSDate(), animate);
                     }
                     break;
                 case TimeKind.Stop:
                     datePicker.Mode = UIDatePickerMode.DateAndTime;
                     if (currentValue != ViewModel.StopDate)
                     {
-                        datePicker.SetDate(ViewModel.StopDate.ToNSDate(), !datePicker.Hidden);
+                        datePicker.SetDate(ViewModel.StopDate.ToNSDate(), animate);
                     }
                     break;
             }
-            DatePickerHidden = startStopView.Selected == TimeKind.None;
         }
 
         private void ForceDimissDatePicker()


### PR DESCRIPTION
Setting the date while the picker is hidden sometimes causes a crash. By setting it right after showing it, this seems to be prevented.