### PR TITLE
Fix for older iphones

### DIFF
--- a/Ross/Info.plist
+++ b/Ross/Info.plist
@@ -5,7 +5,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>8.1</string>
+	<string>7.1</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/Ross/ViewControllers/MainViewController.cs
+++ b/Ross/ViewControllers/MainViewController.cs
@@ -391,7 +391,6 @@ namespace Toggl.Ross.ViewControllers
         {
             UIImage img = null;
             var allPngImageNames = NSBundle.MainBundle.PathsForResources("png");
-
             foreach (var imgName in allPngImageNames)
             {
                 if (imgName.Contains("LaunchImage"))

--- a/Ross/ViewControllers/MainViewController.cs
+++ b/Ross/ViewControllers/MainViewController.cs
@@ -391,12 +391,13 @@ namespace Toggl.Ross.ViewControllers
         {
             UIImage img = null;
             var allPngImageNames = NSBundle.MainBundle.PathsForResources("png");
+
             foreach (var imgName in allPngImageNames)
             {
                 if (imgName.Contains("LaunchImage"))
                 {
                     img = UIImage.FromBundle(imgName);
-                    if (img.CurrentScale.Equals(UIScreen.MainScreen.Scale) && img.Size.Equals(UIScreen.MainScreen.Bounds.Size))
+                    if (img != null && img.CurrentScale.Equals(UIScreen.MainScreen.Scale) && img.Size.Equals(UIScreen.MainScreen.Bounds.Size))
                         return img;
                 }
             }


### PR DESCRIPTION
"Applications using Launch Screen Files and targetting iOS 7.1 and earlier need to also include a Launch Image in an Asset Catalog."

Since the LaunchImages we're checking are not guaranteed to be there for some iPhones, I'm adding a null check.