### PR TITLE
made start-date editable on running time entry, fixes #1642

### DIFF
--- a/Ross/AppDelegate.cs
+++ b/Ross/AppDelegate.cs
@@ -118,7 +118,7 @@ namespace Toggl.Ross
             var config = Google.InstanceID.Config.DefaultConfig;
             Google.InstanceID.InstanceId.SharedInstance.Start(config);
 
-            RxChain.Send(new DataMsg.RegisterPush(deviceToken));
+            RxChain.Send(new DataMsg.RegisterPush(deviceToken.ToString()));
         }
 
         public override void DidReceiveRemoteNotification(UIApplication application, NSDictionary userInfo, Action<UIBackgroundFetchResult> completionHandler)

--- a/Ross/ViewControllers/EditTimeEntryViewController.cs
+++ b/Ross/ViewControllers/EditTimeEntryViewController.cs
@@ -468,7 +468,8 @@ namespace Toggl.Ross.ViewControllers
             switch (startStopView.Selected)
             {
                 case TimeKind.Start:
-                    datePicker.Mode = ViewModel.IsRunning ? UIDatePickerMode.Time : UIDatePickerMode.DateAndTime;
+                    datePicker.Mode = UIDatePickerMode.DateAndTime;
+                    datePicker.MaximumDate = (NSDate)(ViewModel.IsRunning ? DateTime.Now : DateTime.Now + TimeSpan.FromDays(356));
                     if (currentValue != ViewModel.StartDate)
                     {
                         datePicker.SetDate(ViewModel.StartDate.ToNSDate(), animate);


### PR DESCRIPTION
Also made the app compile, by converting the deviceToken.ToString() (might need testing, @monday8am ).