### PR TITLE
Fix #1660

### DIFF
--- a/Phoebe/Data/ISyncDataStore.cs
+++ b/Phoebe/Data/ISyncDataStore.cs
@@ -15,7 +15,7 @@ namespace Toggl.Phoebe.Data
         int GetQueueSize(string queueId);
         bool TryEnqueue(string queueId, string json);
         bool TryDequeue(string queueId, out string json);
-        bool TryPeek(string queueId, out string json);
+        bool TryPeekQueue(string queueId, out string json);
         int ResetQueue(string queueId);
     }
 

--- a/Phoebe/Reactive/StoreManager.cs
+++ b/Phoebe/Reactive/StoreManager.cs
@@ -5,6 +5,7 @@ using System.Reactive.Subjects;
 using Toggl.Phoebe.Logging;
 using Toggl.Phoebe.Data;
 using XPlatUtils;
+using System.Threading.Tasks.Dataflow;
 
 namespace Toggl.Phoebe.Reactive
 {
@@ -19,6 +20,7 @@ namespace Toggl.Phoebe.Reactive
 
         private AppState appStateUnsafe;
         private readonly object appStateLock = new object();
+        private const int BufferSize = 100;
 
         public AppState AppState
         {
@@ -43,39 +45,46 @@ namespace Toggl.Phoebe.Reactive
             Singleton = null;
         }
 
-        readonly Subject<Tuple<DataMsg, RxChain.Continuation>> subject1 = new Subject<Tuple<DataMsg, RxChain.Continuation>> ();
-        readonly Subject<DataSyncMsg<AppState>> subject2 = new Subject<DataSyncMsg<AppState>> ();
+        readonly Subject<Tuple<DataMsg, RxChain.Continuation>> subject1 = new Subject<Tuple<DataMsg, RxChain.Continuation>>();
+        readonly Subject<DataSyncMsg<AppState>> subject2 = new Subject<DataSyncMsg<AppState>>();
 
         StoreManager(AppState initState, Reducer<AppState> reducer)
         {
             AppState = initState;
-            var initSyncMsg = DataSyncMsg.Create(initState);
 
-            subject1
-            .Scan(initSyncMsg, (acc, tuple) =>
+            // TPL block to buffer messages and  delay execution if needed
+            var blockOptions = new ExecutionDataflowBlockOptions
             {
+                MaxDegreeOfParallelism = 1,
+                BoundedCapacity = BufferSize
+            };
+            var processingBlock = new ActionBlock<Tuple<DataMsg, RxChain.Continuation>>(tuple =>
+            {
+                var state = AppState;
                 DataSyncMsg<AppState> msg;
                 try
                 {
-                    msg = reducer.Reduce(acc.State, tuple.Item1);
+                    msg = reducer.Reduce(state, tuple.Item1);
                 }
                 catch (Exception ex)
                 {
-                    var log = ServiceContainer.Resolve<ILogger> ();
+                    var log = ServiceContainer.Resolve<ILogger>();
                     log.Error(GetType().Name, ex, "Failed to handle DataMsg: {0}", tuple.Item1.GetType().Name);
-                    msg = DataSyncMsg.Create(acc.State);
+                    msg = DataSyncMsg.Create(state);
                 }
+
+                var syncMsg = tuple.Item2 == null ? msg : new DataSyncMsg<AppState>(msg.State, msg.ServerRequests, tuple.Item2);
                 AppState = msg.State;
-                return tuple.Item2 == null ? msg : new DataSyncMsg<AppState> (msg.State, msg.ServerRequests, tuple.Item2);
-            })
-            .Subscribe(syncMsg =>
-            {
+
                 // Call message continuation after executing reducers
                 if (syncMsg.Continuation != null && syncMsg.Continuation.LocalOnly)
-                    syncMsg.Continuation.Invoke(syncMsg.State);
+                    System.Threading.Tasks.Task.Run(() => syncMsg.Continuation.Invoke(syncMsg.State));
 
                 subject2.OnNext(syncMsg);
-            });
+            }, blockOptions);
+
+
+            subject1.Subscribe(processingBlock.AsObserver());
         }
 
         public void Send(DataMsg msg, RxChain.Continuation cont)
@@ -88,7 +97,7 @@ namespace Toggl.Phoebe.Reactive
             return subject2.AsObservable();
         }
 
-        public IObservable<T> Observe<T> (Func<DataSyncMsg<AppState>, T> selector)
+        public IObservable<T> Observe<T>(Func<DataSyncMsg<AppState>, T> selector)
         {
             return Observe().Select(syncMsg => selector(syncMsg));
         }

--- a/Phoebe/Reactive/SyncManager.cs
+++ b/Phoebe/Reactive/SyncManager.cs
@@ -243,7 +243,7 @@ namespace Toggl.Phoebe.Reactive
             string json = null;
             List<string> conflicting = new List<string>();
 
-            if (dataStore.TryPeek(QueueId, out json))
+            if (dataStore.TryPeekQueue(QueueId, out json))
             {
                 if (isConnected)
                 {
@@ -274,7 +274,7 @@ namespace Toggl.Phoebe.Reactive
                                 throw;
                             }
                         }
-                        while (dataStore.TryPeek(QueueId, out json));
+                        while (dataStore.TryPeekQueue(QueueId, out json));
 
                         // Put back in the queue conflicting items (if any)
                         foreach (var conflict in conflicting)

--- a/Tests/Data/Migration/MigrateV0toV1Test.cs
+++ b/Tests/Data/Migration/MigrateV0toV1Test.cs
@@ -435,7 +435,7 @@ namespace Toggl.Phoebe.Tests.Data.Migration
         }
 
         [Test]
-        public void TestSettingsMigration()
+        public async System.Threading.Tasks.Task TestSettingsMigration()
         {
             // Settings are updated using a reducer.
             // We need to init the state first.
@@ -453,26 +453,39 @@ namespace Toggl.Phoebe.Tests.Data.Migration
             migrate();
 
             // Update state with migration data.
-            RxChain.Send(new DataMsg.InitStateAfterMigration());
-            var newSettings = StoreManager.Singleton.AppState.Settings;
+            var tcs = new System.Threading.Tasks.TaskCompletionSource<bool>();
+            RxChain.Send(new DataMsg.InitStateAfterMigration(), new RxChain.Continuation(state =>
+            {
+                try
+                {
+                    var newSettings = state.Settings;
 
-            // Check settings.
-            Assert.That(newSettings.ChooseProjectForNew, Is.EqualTo(oldSettings.ChooseProjectForNew));
-            Assert.That(newSettings.PushToken, Is.EqualTo(oldSettings.GcmRegistrationId));
-            Assert.That(newSettings.GetChangesLastRun, Is.EqualTo(oldSettings.SyncLastRun));
-            Assert.That(newSettings.GroupedEntries, Is.EqualTo(oldSettings.GroupedTimeEntries));
-            Assert.That(newSettings.IdleNotification, Is.EqualTo(oldSettings.IdleNotification));
-            Assert.That(newSettings.LastAppVersion, Is.EqualTo(oldSettings.LastAppVersion));
-            // newSettings.lastReportZoom uses default value.
-            // newSettings.ProjectSort is migrated with the default value cause is a new setting.
-            Assert.That(newSettings.ReportsCurrentItem, Is.EqualTo(oldSettings.ReportsCurrentItem));
-            Assert.That(newSettings.RossReadDurOnlyNotice, Is.EqualTo(oldSettings.RossReadDurOnlyNotice));
-            Assert.That(newSettings.ShowNotification, Is.EqualTo(oldSettings.ShowNotification));
-            Assert.That(newSettings.ShowWelcome, Is.EqualTo(oldSettings.ShowWelcome));
-            Assert.That(newSettings.UseDefaultTag, Is.EqualTo(oldSettings.UseDefaultTag));
-            Assert.That(newSettings.UserId, Is.EqualTo(oldSettings.UserId));
+                    // Check settings.
+                    Assert.That(newSettings.ChooseProjectForNew, Is.EqualTo(oldSettings.ChooseProjectForNew));
+                    Assert.That(newSettings.PushToken, Is.EqualTo(oldSettings.GcmRegistrationId));
+                    Assert.That(newSettings.GetChangesLastRun, Is.EqualTo(oldSettings.SyncLastRun));
+                    Assert.That(newSettings.GroupedEntries, Is.EqualTo(oldSettings.GroupedTimeEntries));
+                    Assert.That(newSettings.IdleNotification, Is.EqualTo(oldSettings.IdleNotification));
+                    Assert.That(newSettings.LastAppVersion, Is.EqualTo(oldSettings.LastAppVersion));
+                    // newSettings.lastReportZoom uses default value.
+                    // newSettings.ProjectSort is migrated with the default value cause is a new setting.
+                    Assert.That(newSettings.ReportsCurrentItem, Is.EqualTo(oldSettings.ReportsCurrentItem));
+                    Assert.That(newSettings.RossReadDurOnlyNotice, Is.EqualTo(oldSettings.RossReadDurOnlyNotice));
+                    Assert.That(newSettings.ShowNotification, Is.EqualTo(oldSettings.ShowNotification));
+                    Assert.That(newSettings.ShowWelcome, Is.EqualTo(oldSettings.ShowWelcome));
+                    Assert.That(newSettings.UseDefaultTag, Is.EqualTo(oldSettings.UseDefaultTag));
+                    Assert.That(newSettings.UserId, Is.EqualTo(oldSettings.UserId));
 
-            RxChain.Cleanup();
+                    RxChain.Cleanup();
+                    tcs.SetResult(true);
+                }
+                catch (Exception err)
+                {
+                    tcs.SetException(err);
+                }
+            }));
+
+            await tcs.Task;
         }
 
         #endregion

--- a/Tests/Test.cs
+++ b/Tests/Test.cs
@@ -36,7 +36,7 @@ namespace Toggl.Phoebe.Tests
             ServiceContainer.Clear();
             if (databasePath != null)
             {
-                File.Delete(databasePath);
+                DatabaseHelper.DeleteDatabase(databasePath);
                 databasePath = null;
             }
         }


### PR DESCRIPTION
Attempt to fix #1660 by doing the following:

- Add a buffer to `StoreManager` as with `SyncManager` to be sure all events are processed sequentially.
- Use a different file for the queue, so `StoreManager` and `SyncManager` don’t try to write the db at the same time.